### PR TITLE
Solution for Potential Inflation of Reward Metrics for Unparseable Go…

### DIFF
--- a/src/open_r1/grpo.py
+++ b/src/open_r1/grpo.py
@@ -68,8 +68,8 @@ def accuracy_reward(completions, solution, **kwargs):
             # Reward 1 if the content is the same as the ground truth, 0 otherwise
             reward = float(verify(answer_parsed, gold_parsed))
         else:
-            # If the gold solution is not parseable, we reward 1 to skip this example
-            reward = 1.0
+            # If the gold solution is not parseable, we reward a neutral reward (0.5) to skip this example
+            reward = 0.5  # Neutral reward
             print("Failed to parse gold solution: ", sol)
         rewards.append(reward)
 


### PR DESCRIPTION
[Solution Pathway #2 in Issue #86](https://github.com/huggingface/open-r1/issues/86)

### **Recap:**
In the def_accuracy(reward) function, the current implementation assigns a reward of 1.0 when the gold solution cannot be parsed. This approach artificially inflates the reported completion metric, as it rewards the model regardless of its actual performance.

[Link to Code](https://github.com/huggingface/open-r1/blob/e2e403daffdfc4c9f62e10af609faa491866aac7/src/open_r1/grpo.py#L41) 

```
if gold_parsed is not None:
    reward = float(verify(answer_parsed, gold_parsed))
else:
    reward = 1.0  # Artificially inflates metrics
    print("Failed to parse gold solution: ", sol)
rewards.append(reward)
```

### **Proposed Fix in This PR:**
Assign a neutral reward of 0.5 for unparseable gold solutions instead of 1.0. This adjustment provides a more balanced evaluation of model performance while still acknowledging the ambiguity of such cases.

```
if gold_parsed is not None:
    reward = float(verify(answer_parsed, gold_parsed))
else:
    reward = 0.5  # Neutral reward
    print("Failed to parse gold solution: ", sol)
rewards.append(reward)
```
