### PR TITLE
Improve repoduction of r1 reported score

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ _deps = [
     "huggingface-hub[cli]>=0.19.2,<1.0",
     "isort>=5.12.0",
     "liger_kernel==0.5.2",
-    "lighteval @ git+https://github.com/huggingface/lighteval.git@4f381b352c0e467b5870a97d41cb66b487a2c503#egg=lighteval[math]",
+    "lighteval @ git+https://github.com/huggingface/lighteval.git@0e462692436e1f0575bdb4c6ef63453ad9bde7d4#egg=lighteval[math]",
     "math-verify>=0.3.2",  # Used for math verification in grpo
     "packaging>=23.0",
     "parameterized>=0.9.0",

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ if stale_egg_info.exists():
 #   * If a dependency is fast-moving (e.g. transformers), pin to the exact version
 _deps = [
     "accelerate>=1.2.1",
-    "bitsandbytes>=0.43.0",
+    "bitsandbytes",
     "black>=24.4.2",
     "datasets>=3.2.0",
     "deepspeed==0.15.4",
@@ -54,7 +54,7 @@ _deps = [
     "isort>=5.12.0",
     "liger_kernel==0.5.2",
     "lighteval @ git+https://github.com/huggingface/lighteval.git@4f381b352c0e467b5870a97d41cb66b487a2c503#egg=lighteval[math]",
-    "math-verify",  # Used for math verification in grpo
+    "math-verify>=0.3.2",  # Used for math verification in grpo
     "packaging>=23.0",
     "parameterized>=0.9.0",
     "pytest",

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ if stale_egg_info.exists():
 #   * If a dependency is fast-moving (e.g. transformers), pin to the exact version
 _deps = [
     "accelerate>=1.2.1",
-    "bitsandbytes",
+    "bitsandbytes>=0.43.0",
     "black>=24.4.2",
     "datasets>=3.2.0",
     "deepspeed==0.15.4",

--- a/slurm/evaluate.slurm
+++ b/slurm/evaluate.slurm
@@ -23,7 +23,12 @@ echo "PYTHON ENV: $(which python)"
 NUM_GPUS=8
 MODEL=$1
 TASK=$2
-MODEL_ARGS="pretrained=$MODEL,dtype=float16,data_parallel_size=$NUM_GPUS,max_model_length=32768,gpu_memory_utilisation=0.8"
+# Check if a third argument is passed, if it is tp then eval with tensor parallelism. Required for larger models
+if [ -n "$3" ] && [ "$3" == "tp" ]; then
+  MODEL_ARGS="pretrained=$MODEL,dtype=float16,tensor_parallel_size=$NUM_GPUS,max_model_length=32768,gpu_memory_utilisation=0.8"
+else
+  MODEL_ARGS="pretrained=$MODEL,dtype=float16,data_parallel_size=$NUM_GPUS,max_model_length=32768,gpu_memory_utilisation=0.8"
+fi
 OUTPUT_DIR=data/evals/$MODEL
 
 

--- a/slurm/evaluate.slurm
+++ b/slurm/evaluate.slurm
@@ -43,6 +43,7 @@ lighteval vllm $MODEL_ARGS "custom|$TASK|0|0" \
     --custom-tasks src/open_r1/evaluate.py \
     --use-chat-template \
     --system-prompt="Please reason step by step, and put your final answer within \boxed{}." \
+    --save-details
     --output-dir $OUTPUT_DIR 
 
 

--- a/src/open_r1/evaluate.py
+++ b/src/open_r1/evaluate.py
@@ -29,7 +29,8 @@ latex_gold_metric = multilingual_extractive_match_metric(
     fallback_mode="first_match",
     precision=5,
     gold_extraction_target=(LatexExtractionConfig(),),
-    pred_extraction_target=(ExprExtractionConfig(), LatexExtractionConfig()),
+    # Match boxed first before trying other regexes
+    pred_extraction_target=(ExprExtractionConfig(), LatexExtractionConfig(boxed_match_priority=0)),
     aggregation_function=max,
 )
 
@@ -38,7 +39,8 @@ expr_gold_metric = multilingual_extractive_match_metric(
     fallback_mode="first_match",
     precision=5,
     gold_extraction_target=(ExprExtractionConfig(),),
-    pred_extraction_target=(ExprExtractionConfig(), LatexExtractionConfig()),
+    # Match boxed first before trying other regexes
+    pred_extraction_target=(ExprExtractionConfig(), LatexExtractionConfig(boxed_match_priority=0)),
     aggregation_function=max,
 )
 

--- a/src/open_r1/evaluate.py
+++ b/src/open_r1/evaluate.py
@@ -55,8 +55,8 @@ def prompt_fn(line, task_name: str = None):
 def aime_prompt_fn(line, task_name: str = None):
     return Doc(
         task_name=task_name,
-        query=line["answer"],
-        choices=[line["solution"]],
+        query=line["problem"],
+        choices=[line["answer"]],
         gold_index=0,
     )
 

--- a/src/open_r1/evaluate.py
+++ b/src/open_r1/evaluate.py
@@ -24,11 +24,20 @@ from lighteval.tasks.requests import Doc
 from lighteval.utils.language import Language
 
 
-metric = multilingual_extractive_match_metric(
+latex_gold_metric = multilingual_extractive_match_metric(
     language=Language.ENGLISH,
     fallback_mode="first_match",
     precision=5,
     gold_extraction_target=(LatexExtractionConfig(),),
+    pred_extraction_target=(ExprExtractionConfig(), LatexExtractionConfig()),
+    aggregation_function=max,
+)
+
+expr_gold_metric = multilingual_extractive_match_metric(
+    language=Language.ENGLISH,
+    fallback_mode="first_match",
+    precision=5,
+    gold_extraction_target=(ExprExtractionConfig(),),
     pred_extraction_target=(ExprExtractionConfig(), LatexExtractionConfig()),
     aggregation_function=max,
 )
@@ -43,12 +52,20 @@ def prompt_fn(line, task_name: str = None):
         gold_index=0,
     )
 
+def aime_prompt_fn(line, task_name: str = None):
+    return Doc(
+        task_name=task_name,
+        query=line["answer"],
+        choices=[line["solution"]],
+        gold_index=0,
+    )
+
 
 # Define tasks
 aime24 = LightevalTaskConfig(
     name="aime24",
     suite=["custom"],
-    prompt_function=prompt_fn,
+    prompt_function=aime_prompt_fn,
     hf_repo="HuggingFaceH4/aime_2024",
     hf_subset="default",
     hf_avail_splits=["train"],
@@ -56,7 +73,7 @@ aime24 = LightevalTaskConfig(
     few_shots_split=None,
     few_shots_select=None,
     generation_size=32768,
-    metric=[metric],
+    metric=[expr_gold_metric],
     version=1,
 )
 math_500 = LightevalTaskConfig(
@@ -70,7 +87,7 @@ math_500 = LightevalTaskConfig(
     few_shots_split=None,
     few_shots_select=None,
     generation_size=32768,
-    metric=[metric],
+    metric=[latex_gold_metric],
     version=1,
 )
 

--- a/src/open_r1/evaluate.py
+++ b/src/open_r1/evaluate.py
@@ -44,15 +44,6 @@ expr_gold_metric = multilingual_extractive_match_metric(
     aggregation_function=max,
 )
 
-expr_gold_metric = multilingual_extractive_match_metric(
-    language=Language.ENGLISH,
-    fallback_mode="first_match",
-    precision=5,
-    gold_extraction_target=(ExprExtractionConfig(),),
-    pred_extraction_target=(ExprExtractionConfig(), LatexExtractionConfig()),
-    aggregation_function=max,
-)
-
 
 def prompt_fn(line, task_name: str = None):
     """Assumes the model is either prompted to emit \\boxed{answer} or does so automatically"""

--- a/src/open_r1/evaluate.py
+++ b/src/open_r1/evaluate.py
@@ -52,6 +52,7 @@ def prompt_fn(line, task_name: str = None):
         gold_index=0,
     )
 
+
 def aime_prompt_fn(line, task_name: str = None):
     return Doc(
         task_name=task_name,

--- a/src/open_r1/grpo.py
+++ b/src/open_r1/grpo.py
@@ -17,7 +17,8 @@ from dataclasses import dataclass, field
 
 from datasets import load_dataset
 
-from math_verify import parse, verify
+from latex2sympy2_extended import NormalizationConfig
+from math_verify import LatexExtractionConfig, parse, verify
 from trl import GRPOConfig, GRPOTrainer, ModelConfig, ScriptArguments, TrlParser, get_peft_config
 
 
@@ -42,13 +43,36 @@ def accuracy_reward(completions, solution, **kwargs):
     contents = [completion[0]["content"] for completion in completions]
     rewards = []
     for content, sol in zip(contents, solution):
-        try:
-            answer = parse(content)
-            reward = float(verify(answer, parse(sol)))
-        except Exception:  # if it fails for any reason, return 0.0
-            reward = 0.0
+        gold_parsed = parse(sol, extraction_mode="first_match", extraction_config=[LatexExtractionConfig()])
+        if len(gold_parsed) != 0:
+            # We require the answer to be provided in correct latex (no malformed operators)
+            answer_parsed = parse(
+                content,
+                extraction_config=[
+                    LatexExtractionConfig(
+                        normalization_config=NormalizationConfig(
+                            nits=False,
+                            malformed_operators=False,
+                            basic_latex=True,
+                            equations=True,
+                            boxed=True,
+                            units=True,
+                        ),
+                        # Ensures that boxed is tried first
+                        boxed_match_priority=0,
+                        try_extract_without_anchor=False,
+                    )
+                ],
+                extraction_mode="first_match",
+            )
+            # Reward 1 if the content is the same as the ground truth, 0 otherwise
+            reward = float(verify(answer_parsed, gold_parsed))
+        else:
+            # If the gold solution is not parseable, we reward 1 to skip this example
+            reward = 1
+            print("Failed to parse gold solution: ", sol)
         rewards.append(reward)
-    # Reward 1 if the content is the same as the ground truth, 0 otherwise
+
     return rewards
 
 


### PR DESCRIPTION
- bumps lighteval to the newest commit
- enforces matching boxed environment first when searching for the answer as the r1 models tend to output this as their final answer.

PS: forgot to swtich branch, but since we squash it doesn't matter
PS: don't merge yet 