### PR TITLE
Adds auto eval callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,6 @@ cython_debug/
 # Temp folders
 data/
 wandb/
+logs/
+eval_results/
+results/

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The HuggingFace Team. All rights reserved.
+# Copyright 2025 The HuggingFace Team. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -1,0 +1,64 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from open_r1.utils.evaluation import SUPPORTED_BENCHMARKS, run_benchmark_jobs
+from open_r1.configs import SFTConfig, GRPOConfig
+from trl import ModelConfig, TrlParser
+
+
+@dataclass
+class ScriptArguments:
+    model_id: str = field(
+        default="deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+        metadata={"help": "The Hub model id to push the model to."},
+    )
+    model_revision: str = field(
+        default="main",
+        metadata={"help": "The Hub model branch to push the model to."},
+    )
+    trust_remote_code: bool = field(default=False, metadata={"help": "Trust the remote code."})
+    benchmarks: List[str] = field(
+        default_factory=lambda: [], metadata={"help": ("The benchmarks to run after training.")}
+    )
+    list_benchmarks: bool = field(default=False, metadata={"help": "List all supported benchmarks."})
+    system_prompt: Optional[str] = field(
+        default=None,
+        metadata={"help": "The system prompt to use for the benchmark."},
+    )
+
+
+def main():
+    parser = TrlParser(ScriptArguments)
+    args = parser.parse_args_and_config()[0]
+    if args.list_benchmarks:
+        print("Supported benchmarks:")
+        for benchmark in SUPPORTED_BENCHMARKS:
+            print(f"  - {benchmark}")
+        return
+    benchmark_args = SFTConfig(
+        output_dir="",
+        hub_model_id=args.model_id,
+        hub_model_revision=args.model_revision,
+        benchmarks=args.benchmarks,
+        system_prompt=args.system_prompt,
+    )
+    run_benchmark_jobs(
+        benchmark_args, ModelConfig(model_name_or_path="", model_revision="", trust_remote_code=args.trust_remote_code)
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/slurm/eval_callback.slurm
+++ b/slurm/eval_callback.slurm
@@ -1,0 +1,76 @@
+#!/bin/bash
+#SBATCH --ntasks-per-node=1
+#SBATCH --gres=gpu:8
+#SBATCH --partition=hopper-prod
+#SBATCH --output=./logs/evaluate/%x-%j.out
+#SBATCH --err=./logs/evaluate/%x-%j.err
+#SBATCH --requeue
+
+set -x -e
+source ~/.bashrc
+conda activate openr1
+
+TASK_NAME=$1
+TASKS=$2
+MODEL_ID=$3
+MODEL_REVISION=$4
+# Optional args
+[ -z "$5"] && TENSOR_PARALLEL=False || TENSOR_PARALLEL=$5
+[ -z "$6"] && TRUST_REMOTE_CODE=False || TRUST_REMOTE_CODE=$6
+# $7 is reserved for system_prompt, see line 51
+NUM_GPUS=$(nvidia-smi -L | wc -l)
+
+# Set Whether to use tensor parallelism or data parallelism
+if [ "$TENSOR_PARALLEL" = "True" ]; then
+    # use TP to shard model across NUM_GPUS
+    export VLLM_WORKER_MULTIPROC_METHOD=spawn
+    MODEL_ARGS="pretrained=$MODEL_ID,revision=$MODEL_REVISION,trust_remote_code=$TRUST_REMOTE_CODE,dtype=bfloat16,tensor_parallel_size=$NUM_GPUS,max_model_length=32768,gpu_memory_utilisation=0.8"
+else
+    MODEL_ARGS="pretrained=$MODEL_ID,revision=$MODEL_REVISION,trust_remote_code=$TRUST_REMOTE_CODE,dtype=bfloat16,data_parallel_size=$NUM_GPUS,max_model_length=32768,gpu_memory_utilisation=0.8"
+fi
+
+LM_EVAL_REPO_ID="open-r1/open-r1-eval-leaderboard"
+MODEL_NAME=$(echo $MODEL_ID | sed 's/\//_/g') # replaces / with _
+DETAILS_REPO_ID="open-r1//details-$MODEL_NAME"
+OUTPUT_DIR="eval_results/$MODEL_ID/$MODEL_REVISION/$TASK_NAME"
+# We need this flag since we run this script from training jobs that use DeepSpeed and the env vars get progated which causes errors during evaluation
+ACCELERATE_USE_DEEPSPEED=false
+# Enable fast downloads
+HF_HUB_ENABLE_HF_TRANSFER=1
+
+echo "Running lighteval script ..."
+echo "Eval results will be saved to $OUTPUT_DIR"
+# Check if "custom" is a substring of TASKS
+if [[ $TASKS == *"custom"* ]]; then
+    echo "Custom task detected. Running custom task evaluation script ..."
+    lighteval vllm $MODEL_ARGS $TASKS \
+    --custom-tasks "src/open_r1/evaluate.py" \
+    --use-chat-template \
+    --output-dir $OUTPUT_DIR \
+    --save-details \
+    ${7:+--system-prompt "$7"}
+else
+    lighteval vllm $MODEL_ARGS $TASKS \
+    --use-chat-template \
+    --output-dir $OUTPUT_DIR \
+    --save-details \
+    ${7:+--system-prompt "$7"}
+fi
+
+OUTPUT_FILEPATHS=$(find $OUTPUT_DIR/results/ -type f \( -name "*.json" \))
+for filepath in $OUTPUT_FILEPATHS; do
+    echo "Uploading $filepath to Hugging Face Hub..."
+    filename=$(basename -- "$filepath")
+    huggingface-cli upload --repo-type space --private $LM_EVAL_REPO_ID $filepath $OUTPUT_DIR/$filename
+done
+
+echo "Uploading details to Hugging Face Hub..."
+DETAILS_FILEPATHS=$(find $OUTPUT_DIR/details/ -type f \( -name "*.parquet" \))
+echo "DETAILS_FILEPATHS: $DETAILS_FILEPATHS"
+TIMESTAMP=$(date +"%Y-%m-%dT%H-%M-%S")
+python src/open_r1/utils/upload_details.py --data_files $DETAILS_FILEPATHS --hub_repo_id $DETAILS_REPO_ID --config_name $MODEL_REVISION.$TASK_NAME.$TIMESTAMP
+    
+echo "Cleaning up ..."
+rm -rf $OUTPUT_DIR
+
+echo "Done!"

--- a/src/open_r1/__init__.py
+++ b/src/open_r1/__init__.py
@@ -11,5 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-

--- a/src/open_r1/__init__.py
+++ b/src/open_r1/__init__.py
@@ -12,25 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.3.0.dev0"
 
-from .configs import DataArguments, DPOConfig, H4ArgumentParser, ModelArguments, SFTConfig
-from .data import apply_chat_template, get_datasets
-from .decontaminate import decontaminate_humaneval
-from .model_utils import get_checkpoint, get_kbit_device_map, get_quantization_config, get_tokenizer
-
-
-__all__ = [
-    "DataArguments",
-    "DPOConfig",
-    "H4ArgumentParser",
-    "ModelArguments",
-    "SFTConfig",
-    "apply_chat_template",
-    "get_datasets",
-    "decontaminate_humaneval",
-    "get_checkpoint",
-    "get_kbit_device_map",
-    "get_quantization_config",
-    "get_tokenizer",
-]

--- a/src/open_r1/configs.py
+++ b/src/open_r1/configs.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2024 The HuggingFace Team. All rights reserved.
+# Copyright 2025 The HuggingFace Team. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,8 +20,6 @@ import trl
 
 
 # TODO: add the shared options with a mixin to reduce code duplication
-
-
 @dataclass
 class GRPOConfig(trl.GRPOConfig):
     """

--- a/src/open_r1/configs.py
+++ b/src/open_r1/configs.py
@@ -43,7 +43,7 @@ class GRPOConfig(trl.GRPOConfig):
     push_to_hub_revision: bool = field(default=False, metadata={"help": ("Whether to push to a Hub revision/branch.")})
     
 @dataclass
-class SFTConfig(trl.GRPOConfig):
+class SFTConfig(trl.SFTConfig):
     """
     args for callbacks, benchmarks etc
     """

--- a/src/open_r1/configs.py
+++ b/src/open_r1/configs.py
@@ -13,17 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
 from dataclasses import dataclass, field
+from typing import Optional
+
 import trl
 
+
 # TODO: add the shared options with a mixin to reduce code duplication
+
 
 @dataclass
 class GRPOConfig(trl.GRPOConfig):
     """
     args for callbacks, benchmarks etc
     """
+
     benchmarks: list[str] = field(
         default_factory=lambda: [],
         metadata={"help": ("The benchmarks to run after training.")},
@@ -41,12 +45,14 @@ class GRPOConfig(trl.GRPOConfig):
     )
     overwrite_hub_revision: bool = field(default=False, metadata={"help": ("Whether to overwrite the Hub revision.")})
     push_to_hub_revision: bool = field(default=False, metadata={"help": ("Whether to push to a Hub revision/branch.")})
-    
+
+
 @dataclass
 class SFTConfig(trl.SFTConfig):
     """
     args for callbacks, benchmarks etc
     """
+
     benchmarks: list[str] = field(
         default_factory=lambda: [],
         metadata={"help": ("The benchmarks to run after training.")},
@@ -64,8 +70,3 @@ class SFTConfig(trl.SFTConfig):
     )
     overwrite_hub_revision: bool = field(default=False, metadata={"help": ("Whether to overwrite the Hub revision.")})
     push_to_hub_revision: bool = field(default=False, metadata={"help": ("Whether to push to a Hub revision/branch.")})
-
-
-
-    
-    

--- a/src/open_r1/configs.py
+++ b/src/open_r1/configs.py
@@ -1,0 +1,71 @@
+# coding=utf-8
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+from dataclasses import dataclass, field
+import trl
+
+# TODO: add the shared options with a mixin to reduce code duplication
+
+@dataclass
+class GRPOConfig(trl.GRPOConfig):
+    """
+    args for callbacks, benchmarks etc
+    """
+    benchmarks: list[str] = field(
+        default_factory=lambda: [],
+        metadata={"help": ("The benchmarks to run after training.")},
+    )
+    callbacks: list[str] = field(
+        default_factory=lambda: [], metadata={"help": ("The callbacks to run during training.")}
+    )
+    system_prompt: Optional[str] = field(
+        default=None,
+        metadata={"help": ("The optional system prompt to use for benchmarking.")},
+    )
+    hub_model_revision: Optional[str] = field(
+        default="main",
+        metadata={"help": ("The Hub model branch to push the model to.")},
+    )
+    overwrite_hub_revision: bool = field(default=False, metadata={"help": ("Whether to overwrite the Hub revision.")})
+    push_to_hub_revision: bool = field(default=False, metadata={"help": ("Whether to push to a Hub revision/branch.")})
+    
+@dataclass
+class SFTConfig(trl.GRPOConfig):
+    """
+    args for callbacks, benchmarks etc
+    """
+    benchmarks: list[str] = field(
+        default_factory=lambda: [],
+        metadata={"help": ("The benchmarks to run after training.")},
+    )
+    callbacks: list[str] = field(
+        default_factory=lambda: [], metadata={"help": ("The callbacks to run during training.")}
+    )
+    system_prompt: Optional[str] = field(
+        default=None,
+        metadata={"help": ("The optional system prompt to use for benchmarking.")},
+    )
+    hub_model_revision: Optional[str] = field(
+        default="main",
+        metadata={"help": ("The Hub model branch to push the model to.")},
+    )
+    overwrite_hub_revision: bool = field(default=False, metadata={"help": ("Whether to overwrite the Hub revision.")})
+    push_to_hub_revision: bool = field(default=False, metadata={"help": ("Whether to push to a Hub revision/branch.")})
+
+
+
+    
+    

--- a/src/open_r1/evaluate.py
+++ b/src/open_r1/evaluate.py
@@ -29,7 +29,7 @@ latex_gold_metric = multilingual_extractive_match_metric(
     fallback_mode="first_match",
     precision=5,
     gold_extraction_target=(LatexExtractionConfig(),),
-    pred_extraction_target=(ExprExtractionConfig(), LatexExtractionConfig()),
+    pred_extraction_target=(ExprExtractionConfig(), LatexExtractionConfig(boxed_match_priority=0)),
     aggregation_function=max,
 )
 
@@ -38,7 +38,7 @@ expr_gold_metric = multilingual_extractive_match_metric(
     fallback_mode="first_match",
     precision=5,
     gold_extraction_target=(ExprExtractionConfig(),),
-    pred_extraction_target=(ExprExtractionConfig(), LatexExtractionConfig()),
+    pred_extraction_target=(ExprExtractionConfig(), LatexExtractionConfig(boxed_match_priority=0)),
     aggregation_function=max,
 )
 

--- a/src/open_r1/grpo.py
+++ b/src/open_r1/grpo.py
@@ -19,8 +19,8 @@ from datasets import load_dataset
 
 from latex2sympy2_extended import NormalizationConfig
 from math_verify import LatexExtractionConfig, parse, verify
-from trl import GRPOConfig, GRPOTrainer, ModelConfig, ScriptArguments, TrlParser, get_peft_config
-
+from trl import GRPOTrainer, ModelConfig, ScriptArguments, TrlParser, get_peft_config
+from.configs import GRPOConfig
 
 @dataclass
 class GRPOScriptArguments(ScriptArguments):
@@ -114,7 +114,9 @@ def main(script_args, training_args, model_args):
         }
 
     dataset = dataset.map(make_conversation)
-    dataset = dataset.remove_columns("messages")
+    if "messages" in dataset.column_names:
+        # (Ed) not sure if this is required
+        dataset = dataset.remove_columns("messages")
 
     # Initialize the GRPO trainer
     trainer = GRPOTrainer(

--- a/src/open_r1/grpo.py
+++ b/src/open_r1/grpo.py
@@ -20,7 +20,9 @@ from datasets import load_dataset
 from latex2sympy2_extended import NormalizationConfig
 from math_verify import LatexExtractionConfig, parse, verify
 from trl import GRPOTrainer, ModelConfig, ScriptArguments, TrlParser, get_peft_config
-from.configs import GRPOConfig
+from open_r1.configs import GRPOConfig
+from open_r1.utils.callbacks import get_callbacks
+
 
 @dataclass
 class GRPOScriptArguments(ScriptArguments):
@@ -126,6 +128,7 @@ def main(script_args, training_args, model_args):
         train_dataset=dataset[script_args.dataset_train_split],
         eval_dataset=dataset[script_args.dataset_test_split] if training_args.eval_strategy != "no" else None,
         peft_config=get_peft_config(model_args),
+        callbacks=get_callbacks(training_args, model_args),
     )
 
     # Train and push the model to the Hub

--- a/src/open_r1/grpo.py
+++ b/src/open_r1/grpo.py
@@ -19,9 +19,9 @@ from datasets import load_dataset
 
 from latex2sympy2_extended import NormalizationConfig
 from math_verify import LatexExtractionConfig, parse, verify
-from trl import GRPOTrainer, ModelConfig, ScriptArguments, TrlParser, get_peft_config
 from open_r1.configs import GRPOConfig
 from open_r1.utils.callbacks import get_callbacks
+from trl import GRPOTrainer, ModelConfig, ScriptArguments, TrlParser, get_peft_config
 
 
 @dataclass

--- a/src/open_r1/sft.py
+++ b/src/open_r1/sft.py
@@ -38,6 +38,8 @@ accelerate launch --config_file=configs/zero3.yaml src/open_r1/sft.py \
 from datasets import load_dataset
 from transformers import AutoTokenizer
 
+from open_r1.configs import SFTConfig
+from open_r1.utils.callbacks import get_callbacks
 from trl import (
     ModelConfig,
     ScriptArguments,
@@ -47,8 +49,7 @@ from trl import (
     get_peft_config,
     get_quantization_config,
 )
-from open_r1.configs import SFTConfig
-from open_r1.utils.callbacks import get_callbacks
+
 
 def main(script_args, training_args, model_args):
     ################

--- a/src/open_r1/sft.py
+++ b/src/open_r1/sft.py
@@ -47,7 +47,8 @@ from trl import (
     get_peft_config,
     get_quantization_config,
 )
-from.configs import SFTConfig
+from open_r1.configs import SFTConfig
+from open_r1.utils.callbacks import get_callbacks
 
 def main(script_args, training_args, model_args):
     ################
@@ -84,6 +85,7 @@ def main(script_args, training_args, model_args):
         eval_dataset=dataset[script_args.dataset_test_split] if training_args.eval_strategy != "no" else None,
         processing_class=tokenizer,
         peft_config=get_peft_config(model_args),
+        callbacks=get_callbacks(training_args, model_args),
     )
 
     trainer.train()

--- a/src/open_r1/sft.py
+++ b/src/open_r1/sft.py
@@ -41,14 +41,13 @@ from transformers import AutoTokenizer
 from trl import (
     ModelConfig,
     ScriptArguments,
-    SFTConfig,
     SFTTrainer,
     TrlParser,
     get_kbit_device_map,
     get_peft_config,
     get_quantization_config,
 )
-
+from.configs import SFTConfig
 
 def main(script_args, training_args, model_args):
     ################

--- a/src/open_r1/utils/callbacks.py
+++ b/src/open_r1/utils/callbacks.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+from typing import List
+
+from transformers import TrainerCallback
+from transformers.trainer_callback import TrainerControl, TrainerState
+from transformers.training_args import TrainingArguments
+
+from .hub import push_to_hub_revision
+from .evaluation import SUPPORTED_BENCHMARKS, run_benchmark_jobs
+def is_slurm_available() -> bool:
+    # returns true if a slurm queueing system is available
+    try:
+        subprocess.run(["sinfo"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return True
+    except FileNotFoundError:
+        return False
+
+
+class DummyConfig:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class PushToHubCallback(TrainerCallback):
+    def __init__(self, model_config, data_config) -> None:
+        self.model_config = model_config
+        self.data_config = data_config
+
+    def on_save(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
+        if state.is_world_process_zero:
+            global_step = state.global_step
+
+            # WARNING: if you use dataclasses.replace(args, ...) the accelerator dist state will be broken, so I do this workaround
+            # Also if you instantiate a new SFTConfig, the accelerator dist state will be broken
+            dummy_config = DummyConfig(
+                hub_model_id=args.hub_model_id,
+                hub_model_revision=f"{args.hub_model_revision}-step-{global_step:09d}",
+                output_dir=f"{args.output_dir}/checkpoint-{global_step}",
+            )
+
+            # TODO: I think this could be made async
+            push_to_hub_revision(dummy_config, extra_ignore_patterns=["*.pt"])  # don't push the optimizer states
+
+            if is_slurm_available():
+                dummy_config.benchmarks = args.benchmarks
+                dummy_config.quants = args.quants
+                run_benchmark_jobs(dummy_config, self.model_config)
+
+
+CALLBACKS = {
+    "push_to_hub": PushToHubCallback,
+}
+
+
+def get_callbacks(sft_config, model_config, data_config) -> List[TrainerCallback]:
+    callbacks = []
+    for callback_name in sft_config.callbacks:
+        if callback_name not in CALLBACKS:
+            raise ValueError(f"Callback {callback_name} not found in CALLBACKS.")
+        callbacks.append(CALLBACKS[callback_name](model_config, data_config))
+
+    return callbacks

--- a/src/open_r1/utils/callbacks.py
+++ b/src/open_r1/utils/callbacks.py
@@ -21,7 +21,7 @@ from transformers import TrainerCallback
 from transformers.trainer_callback import TrainerControl, TrainerState
 from transformers.training_args import TrainingArguments
 
-from .evaluation import SUPPORTED_BENCHMARKS, run_benchmark_jobs
+from .evaluation import run_benchmark_jobs
 from .hub import push_to_hub_revision
 
 

--- a/src/open_r1/utils/callbacks.py
+++ b/src/open_r1/utils/callbacks.py
@@ -21,8 +21,10 @@ from transformers import TrainerCallback
 from transformers.trainer_callback import TrainerControl, TrainerState
 from transformers.training_args import TrainingArguments
 
-from .hub import push_to_hub_revision
 from .evaluation import SUPPORTED_BENCHMARKS, run_benchmark_jobs
+from .hub import push_to_hub_revision
+
+
 def is_slurm_available() -> bool:
     # returns true if a slurm queueing system is available
     try:

--- a/src/open_r1/utils/evaluation.py
+++ b/src/open_r1/utils/evaluation.py
@@ -66,7 +66,7 @@ def run_lighteval_job(benchmark: str, training_args: Union["SFTConfig", "GRPOCon
     cmd = VLLM_SLURM_PREFIX.copy()
     cmd_args = [
         f"--gres=gpu:{num_gpus}",
-        f"--job-name=open-r1_{benchmark}_{model_name.split('/')[-1]}_{model_revision}",
+        f"--job-name=or1_{benchmark}_{model_name.split('/')[-1]}_{model_revision}",
         "slurm/eval_callback.slurm",
         benchmark,
         f'"{task_list}"',

--- a/src/open_r1/utils/evaluation.py
+++ b/src/open_r1/utils/evaluation.py
@@ -1,0 +1,95 @@
+import subprocess
+from typing import TYPE_CHECKING, Dict, Union
+
+from .hub import get_gpu_count_for_vllm, get_param_count_from_repo_id
+
+if TYPE_CHECKING:
+    from trl import GRPOConfig, SFTConfig, ModelConfig
+
+
+import os
+
+# We need a special environment setup to launch vLLM from within Slurm training jobs.
+# - Reference code: https://github.com/huggingface/brrr/blob/c55ba3505686d690de24c7ace6487a5c1426c0fd/brrr/lighteval/one_job_runner.py#L105
+# - Slack thread: https://huggingface.slack.com/archives/C043JTYE1MJ/p1726566494958269
+user_home_directory = os.path.expanduser("~")
+VLLM_SLURM_PREFIX = [
+    "env",
+    "-i",
+    "bash",
+    "-c",
+    f"for f in /etc/profile.d/*.sh; do source $f; done; export HOME={user_home_directory}; sbatch ",
+]
+
+def register_lighteval_task(
+    configs: Dict[str, str], eval_suite: str, task_name: str, task_list: str, num_fewshot: int = 0
+):
+    """Registers a LightEval task configuration.
+
+    - Core tasks can be added from this table: https://github.com/huggingface/lighteval/blob/main/src/lighteval/tasks/tasks_table.jsonl
+    - Custom tasks that require their own metrics / scripts, should be stored in scripts/evaluation/extended_lighteval_tasks
+
+    Args:
+        configs (Dict[str, str]): The dictionary to store the task configuration.
+        eval_suite (str, optional): The evaluation suite.
+        task_name (str): The name of the task.
+        task_list (str): The comma-separated list of tasks in the format "extended|{task_name}|{num_fewshot}|0" or "lighteval|{task_name}|{num_fewshot}|0".
+        num_fewshot (int, optional): The number of few-shot examples. Defaults to 0.
+        is_custom_task (bool, optional): Whether the task is a custom task. Defaults to False.
+    """
+    # Format task list in lighteval format
+    task_list = ",".join(f"{eval_suite}|{task}|{num_fewshot}|0" for task in task_list.split(","))
+    configs[task_name] = task_list
+
+
+LIGHTEVAL_TASKS = {}
+
+register_lighteval_task(LIGHTEVAL_TASKS, "custom", "math_500", "math_500", 0)
+register_lighteval_task(LIGHTEVAL_TASKS, "custom", "aime24", "aime24", 0)
+
+def get_lighteval_tasks():
+    return list(LIGHTEVAL_TASKS.keys())
+
+SUPPORTED_BENCHMARKS = get_lighteval_tasks()
+
+def run_lighteval_job(benchmark: str, training_args: Union["SFTConfig", "GRPOConfig"], model_args: "ModelConfig") -> None:
+    task_list = LIGHTEVAL_TASKS[benchmark]
+    model_name = training_args.hub_model_id
+    model_revision = training_args.hub_model_revision
+    # For large models >= 30b params or those running the MATH benchmark, we need to shard them across the GPUs to avoid OOM
+    num_gpus = get_gpu_count_for_vllm(model_name, model_revision)
+    if get_param_count_from_repo_id(model_name) >= 30_000_000_000:
+        tensor_parallel = True
+    else:
+        tensor_parallel = False
+
+    cmd = VLLM_SLURM_PREFIX.copy()
+    cmd_args = [
+        f"--gres=gpu:{num_gpus}",
+        f"--job-name=open-r1_{benchmark}_{model_name.split('/')[-1]}_{model_revision}",
+        "slurm/eval_callback.slurm",
+        benchmark,
+        f'"{task_list}"',
+        model_name,
+        model_revision,
+        f"{tensor_parallel}",
+        f"{model_args.trust_remote_code}",
+    ]
+    if training_args.system_prompt is not None:
+        cmd_args.append(f"--system_prompt={training_args.system_prompt}")
+    cmd[-1] += " " + " ".join(cmd_args)
+    subprocess.run(cmd, check=True)
+
+def run_benchmark_jobs(training_args: Union["SFTConfig", "GRPOConfig"], model_args: "ModelConfig") -> None:
+    benchmarks = training_args.benchmarks
+    if len(benchmarks) == 1 and benchmarks[0] == "all":
+        benchmarks = get_lighteval_tasks()
+        # Evaluate on all supported benchmarks. Later we may want to include a `chat` option
+        # that just evaluates on `ifeval` and `mt_bench` etc.
+
+    for benchmark in benchmarks:
+        print(f"Launching benchmark `{benchmark}`")
+        if benchmark in get_lighteval_tasks():
+            run_lighteval_job(benchmark, training_args, model_args)
+        else:
+            raise ValueError(f"Unknown benchmark {benchmark}")

--- a/src/open_r1/utils/evaluation.py
+++ b/src/open_r1/utils/evaluation.py
@@ -3,11 +3,12 @@ from typing import TYPE_CHECKING, Dict, Union
 
 from .hub import get_gpu_count_for_vllm, get_param_count_from_repo_id
 
+
 if TYPE_CHECKING:
     from trl import GRPOConfig, SFTConfig, ModelConfig
 
-
 import os
+
 
 # We need a special environment setup to launch vLLM from within Slurm training jobs.
 # - Reference code: https://github.com/huggingface/brrr/blob/c55ba3505686d690de24c7ace6487a5c1426c0fd/brrr/lighteval/one_job_runner.py#L105
@@ -20,6 +21,7 @@ VLLM_SLURM_PREFIX = [
     "-c",
     f"for f in /etc/profile.d/*.sh; do source $f; done; export HOME={user_home_directory}; sbatch ",
 ]
+
 
 def register_lighteval_task(
     configs: Dict[str, str], eval_suite: str, task_name: str, task_list: str, num_fewshot: int = 0
@@ -47,12 +49,17 @@ LIGHTEVAL_TASKS = {}
 register_lighteval_task(LIGHTEVAL_TASKS, "custom", "math_500", "math_500", 0)
 register_lighteval_task(LIGHTEVAL_TASKS, "custom", "aime24", "aime24", 0)
 
+
 def get_lighteval_tasks():
     return list(LIGHTEVAL_TASKS.keys())
 
+
 SUPPORTED_BENCHMARKS = get_lighteval_tasks()
 
-def run_lighteval_job(benchmark: str, training_args: Union["SFTConfig", "GRPOConfig"], model_args: "ModelConfig") -> None:
+
+def run_lighteval_job(
+    benchmark: str, training_args: Union["SFTConfig", "GRPOConfig"], model_args: "ModelConfig"
+) -> None:
     task_list = LIGHTEVAL_TASKS[benchmark]
     model_name = training_args.hub_model_id
     model_revision = training_args.hub_model_revision
@@ -79,6 +86,7 @@ def run_lighteval_job(benchmark: str, training_args: Union["SFTConfig", "GRPOCon
         cmd_args.append(f"--system_prompt={training_args.system_prompt}")
     cmd[-1] += " " + " ".join(cmd_args)
     subprocess.run(cmd, check=True)
+
 
 def run_benchmark_jobs(training_args: Union["SFTConfig", "GRPOConfig"], model_args: "ModelConfig") -> None:
     benchmarks = training_args.benchmarks

--- a/src/open_r1/utils/hub.py
+++ b/src/open_r1/utils/hub.py
@@ -16,7 +16,6 @@
 
 import logging
 import re
-import sys
 
 from transformers import AutoConfig
 

--- a/src/open_r1/utils/hub.py
+++ b/src/open_r1/utils/hub.py
@@ -19,7 +19,7 @@ import re
 import sys
 
 from transformers import AutoConfig
-from trl import GRPOConfig, SFTConfig
+
 from huggingface_hub import (
     create_branch,
     create_repo,
@@ -30,6 +30,8 @@ from huggingface_hub import (
     repo_exists,
     upload_folder,
 )
+from trl import GRPOConfig, SFTConfig
+
 
 logger = logging.getLogger(__name__)
 
@@ -115,8 +117,9 @@ def get_param_count_from_repo_id(repo_id: str) -> int:
 
 
 def get_gpu_count_for_vllm(model_name: str, revision: str = "main", num_gpus: int = 8) -> int:
-    """vLLM enforces a constraint that the number of attention heads must be divisible by the number of GPUs and 64 must be divisible by the number of GPUs. 
-       This function calculates the number of GPUs to use for decoding based on the number of attention heads in the model."""
+    """vLLM enforces a constraint that the number of attention heads must be divisible by the number of GPUs and 64 must be divisible by the number of GPUs.
+    This function calculates the number of GPUs to use for decoding based on the number of attention heads in the model.
+    """
     config = AutoConfig.from_pretrained(model_name, revision=revision, trust_remote_code=True)
     # Get number of attention heads
     num_heads = config.num_attention_heads

--- a/src/open_r1/utils/hub.py
+++ b/src/open_r1/utils/hub.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import re
+import sys
+
+from transformers import AutoConfig
+from trl import GRPOConfig, SFTConfig
+from huggingface_hub import (
+    create_branch,
+    create_repo,
+    get_safetensors_metadata,
+    list_repo_commits,
+    list_repo_files,
+    list_repo_refs,
+    repo_exists,
+    upload_folder,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def push_to_hub_revision(training_args: SFTConfig | GRPOConfig, extra_ignore_patterns=[]) -> bool:
+    """Pushes the model to branch on a Hub repo."""
+
+    # Create a repo if it doesn't exist yet
+    repo_url = create_repo(repo_id=training_args.hub_model_id, private=True, exist_ok=True)
+    # Get initial commit to branch from
+    initial_commit = list_repo_commits(training_args.hub_model_id)[-1]
+    # Now create the branch we'll be pushing to
+    create_branch(
+        repo_id=training_args.hub_model_id,
+        branch=training_args.hub_model_revision,
+        revision=initial_commit.commit_id,
+        exist_ok=True,
+    )
+    logger.info(f"Created target repo at {repo_url}")
+    logger.info(f"Pushing to the Hub revision {training_args.hub_model_revision}...")
+    ignore_patterns = ["checkpoint-*", "*.pth"]
+    ignore_patterns.extend(extra_ignore_patterns)
+    upload_folder(
+        repo_id=training_args.hub_model_id,
+        folder_path=training_args.output_dir,
+        revision=training_args.hub_model_revision,
+        commit_message=f"Add {training_args.hub_model_revision} checkpoint",
+        ignore_patterns=ignore_patterns,
+    )
+    logger.info(f"Pushed to {repo_url} revision {training_args.hub_model_revision} successfully!")
+
+    return True
+
+
+def check_hub_revision_exists(training_args: SFTConfig | GRPOConfig):
+    """Checks if a given Hub revision exists."""
+    if repo_exists(training_args.hub_model_id):
+        if training_args.push_to_hub_revision is True:
+            # First check if the revision exists
+            revisions = [rev.name for rev in list_repo_refs(training_args.hub_model_id).branches]
+            # If the revision exists, we next check it has a README file
+            if training_args.hub_model_revision in revisions:
+                repo_files = list_repo_files(
+                    repo_id=training_args.hub_model_id, revision=training_args.hub_model_revision
+                )
+                if "README.md" in repo_files and training_args.overwrite_hub_revision is False:
+                    raise ValueError(
+                        f"Revision {training_args.hub_model_revision} already exists. "
+                        "Use --overwrite_hub_revision to overwrite it."
+                    )
+
+
+def get_param_count_from_repo_id(repo_id: str) -> int:
+    """Function to get model param counts from safetensors metadata or find patterns like 42m, 1.5b, 0.5m or products like 8x7b in a repo ID."""
+    try:
+        metadata = get_safetensors_metadata(repo_id)
+        return list(metadata.parameter_count.values())[0]
+    except Exception:
+        # Pattern to match products (like 8x7b) and single values (like 42m)
+        pattern = r"((\d+(\.\d+)?)(x(\d+(\.\d+)?))?)([bm])"
+        matches = re.findall(pattern, repo_id.lower())
+
+        param_counts = []
+        for full_match, number1, _, _, number2, _, unit in matches:
+            if number2:  # If there's a second number, it's a product
+                number = float(number1) * float(number2)
+            else:  # Otherwise, it's a single value
+                number = float(number1)
+
+            if unit == "b":
+                number *= 1_000_000_000  # Convert to billion
+            elif unit == "m":
+                number *= 1_000_000  # Convert to million
+
+            param_counts.append(number)
+
+        if len(param_counts) > 0:
+            # Return the largest number
+            return int(max(param_counts))
+        else:
+            # Return -1 if no match found
+            return -1
+
+
+def get_gpu_count_for_vllm(model_name: str, revision: str = "main", num_gpus: int = 8) -> int:
+    """vLLM enforces a constraint that the number of attention heads must be divisible by the number of GPUs and 64 must be divisible by the number of GPUs. 
+       This function calculates the number of GPUs to use for decoding based on the number of attention heads in the model."""
+    config = AutoConfig.from_pretrained(model_name, revision=revision, trust_remote_code=True)
+    # Get number of attention heads
+    num_heads = config.num_attention_heads
+    # Reduce num_gpus so that num_heads is divisible by num_gpus and 64 is divisible by num_gpus
+    while num_heads % num_gpus != 0 or 64 % num_gpus != 0:
+        logger.info(f"Reducing num_gpus from {num_gpus} to {num_gpus - 1} to make num_heads divisible by num_gpus")
+        num_gpus -= 1
+    return num_gpus

--- a/src/open_r1/utils/upload_details.py
+++ b/src/open_r1/utils/upload_details.py
@@ -27,7 +27,6 @@ from dataclasses import dataclass, field
 from typing import List
 
 from datasets import load_dataset
-
 from transformers import HfArgumentParser
 
 

--- a/src/open_r1/utils/upload_details.py
+++ b/src/open_r1/utils/upload_details.py
@@ -1,0 +1,56 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Push the details from a LightEval run to the Hub.
+
+Usage:
+
+python scripts/evaluation/lighteval/upload_details.py \
+    --data_files {path_to_parquet_file} \
+    --hub_repo_id {hub_repo_id} \
+    --config_name {config_name}
+"""
+
+from dataclasses import dataclass, field
+from typing import List
+
+from datasets import load_dataset
+
+from transformers import HfArgumentParser
+
+
+@dataclass
+class ScriptArguments:
+    data_files: List[str] = field(default_factory=list)
+    hub_repo_id: str = None
+    config_name: str = None
+
+
+def main():
+    parser = HfArgumentParser(ScriptArguments)
+    args = parser.parse()
+
+    if all(file.endswith(".json") for file in args.data_files):
+        ds = load_dataset("json", data_files=args.data_files)
+    elif all(file.endswith(".jsonl") for file in args.data_files):
+        ds = load_dataset("json", data_files=args.data_files)
+    else:
+        ds = load_dataset("parquet", data_files=args.data_files)
+    url = ds.push_to_hub(args.hub_repo_id, config_name=args.config_name, private=True)
+    print(f"Dataset available at: {url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/open_r1/utils/upload_details.py
+++ b/src/open_r1/utils/upload_details.py
@@ -17,7 +17,7 @@ Push the details from a LightEval run to the Hub.
 
 Usage:
 
-python scripts/evaluation/lighteval/upload_details.py \
+python src/open_r1/utils/upload_details.py \
     --data_files {path_to_parquet_file} \
     --hub_repo_id {hub_repo_id} \
     --config_name {config_name}


### PR DESCRIPTION
Adds a push to hub callback to will push a checkpoint to the hub with the appropriate revision anme and launch evals.



Example of callback usage
```
accelerate launch src/open_r1/sft.py ... --hub_model_id open-r1/<YOUR_MODEL> --save_strategy steps --save_steps 100 --callbacks push_to_hub_revision --benchmarks math_500 aime24 ...
```
Can be run post training with:
```
python scripts/run_benchmarks.py --model=<MODEL> --revision <REVISION> --benchmarks math_500 aime24
```

Still TODO: 
- update the push to hub sync to happen asynchronously
