### PR TITLE
Adds async model push to PushToHubRevisionCallback

### DIFF
--- a/src/open_r1/utils/callbacks.py
+++ b/src/open_r1/utils/callbacks.py
@@ -57,12 +57,15 @@ class PushToHubRevisionCallback(TrainerCallback):
                 system_prompt=args.system_prompt,
             )
 
-            # TODO: I think this could be made async
-            push_to_hub_revision(dummy_config, extra_ignore_patterns=["*.pt"])  # don't push the optimizer states
-
+            future = push_to_hub_revision(dummy_config, extra_ignore_patterns=["*.pt"])  # don't push the optimizer states
+            
             if is_slurm_available():
                 dummy_config.benchmarks = args.benchmarks
-                run_benchmark_jobs(dummy_config, self.model_config)
+                def run_benchmark_callback(_):
+                    print(f"Checkpoint {global_step} pushed to hub.")
+                    run_benchmark_jobs(dummy_config, self.model_config)
+                
+                future.add_done_callback(run_benchmark_callback)
 
 
 CALLBACKS = {

--- a/src/open_r1/utils/callbacks.py
+++ b/src/open_r1/utils/callbacks.py
@@ -57,14 +57,17 @@ class PushToHubRevisionCallback(TrainerCallback):
                 system_prompt=args.system_prompt,
             )
 
-            future = push_to_hub_revision(dummy_config, extra_ignore_patterns=["*.pt"])  # don't push the optimizer states
-            
+            future = push_to_hub_revision(
+                dummy_config, extra_ignore_patterns=["*.pt"]
+            )  # don't push the optimizer states
+
             if is_slurm_available():
                 dummy_config.benchmarks = args.benchmarks
+
                 def run_benchmark_callback(_):
                     print(f"Checkpoint {global_step} pushed to hub.")
                     run_benchmark_jobs(dummy_config, self.model_config)
-                
+
                 future.add_done_callback(run_benchmark_callback)
 
 

--- a/src/open_r1/utils/hub.py
+++ b/src/open_r1/utils/hub.py
@@ -18,6 +18,7 @@ import logging
 import re
 
 from transformers import AutoConfig
+from concurrent.futures import Future
 
 from huggingface_hub import (
     create_branch,
@@ -35,7 +36,7 @@ from trl import GRPOConfig, SFTConfig
 logger = logging.getLogger(__name__)
 
 
-def push_to_hub_revision(training_args: SFTConfig | GRPOConfig, extra_ignore_patterns=[]) -> bool:
+def push_to_hub_revision(training_args: SFTConfig | GRPOConfig, extra_ignore_patterns=[]) -> Future:
     """Pushes the model to branch on a Hub repo."""
 
     # Create a repo if it doesn't exist yet
@@ -53,16 +54,18 @@ def push_to_hub_revision(training_args: SFTConfig | GRPOConfig, extra_ignore_pat
     logger.info(f"Pushing to the Hub revision {training_args.hub_model_revision}...")
     ignore_patterns = ["checkpoint-*", "*.pth"]
     ignore_patterns.extend(extra_ignore_patterns)
-    upload_folder(
+    future = upload_folder(
         repo_id=training_args.hub_model_id,
         folder_path=training_args.output_dir,
         revision=training_args.hub_model_revision,
         commit_message=f"Add {training_args.hub_model_revision} checkpoint",
         ignore_patterns=ignore_patterns,
+        run_as_future=True,
+        
     )
     logger.info(f"Pushed to {repo_url} revision {training_args.hub_model_revision} successfully!")
 
-    return True
+    return future
 
 
 def check_hub_revision_exists(training_args: SFTConfig | GRPOConfig):

--- a/src/open_r1/utils/hub.py
+++ b/src/open_r1/utils/hub.py
@@ -16,9 +16,9 @@
 
 import logging
 import re
+from concurrent.futures import Future
 
 from transformers import AutoConfig
-from concurrent.futures import Future
 
 from huggingface_hub import (
     create_branch,
@@ -61,7 +61,6 @@ def push_to_hub_revision(training_args: SFTConfig | GRPOConfig, extra_ignore_pat
         commit_message=f"Add {training_args.hub_model_revision} checkpoint",
         ignore_patterns=ignore_patterns,
         run_as_future=True,
-        
     )
     logger.info(f"Pushed to {repo_url} revision {training_args.hub_model_revision} successfully!")
 


### PR DESCRIPTION
The model `PushToHubRevisionCallback` was pausing training while the model was uploaded, this PR changes this to happen asynchronously.

Note the write of weight to disk happens in parallel, so it is best to set `output_dir` to `/scratch/...` so that the write/read is faster.