### PR TITLE
Update grpo.py to fix errors during create_model_card

### DIFF
--- a/src/open_r1/grpo.py
+++ b/src/open_r1/grpo.py
@@ -202,9 +202,7 @@ def main(script_args, training_args, model_args):
 
     # Save everything else on main process
     kwargs = {
-        "finetuned_from": model_args.model_name_or_path,
-        "dataset": list(script_args.dataset_name),
-        "dataset_tags": list(script_args.dataset_name),
+        "dataset_name": script_args.dataset_name,
         "tags": ["open-r1"],
     }
     if trainer.accelerator.is_main_process:


### PR DESCRIPTION
Latest version of [GRPOTrainer](https://huggingface.co/docs/trl/grpo_trainer#trl.GRPOTrainer.create_model_card) in trl doesn't support arguments like `pretrained_from`. Current code will throw errors like `TypeError: GRPOTrainer.create_model_card() got an unexpected keyword argument 'pretrained_from`' during model uploading.

Since we're installing the latest version of GRPOTrainer as specified in [setup.py](https://github.com/huggingface/open-r1/blob/main/setup.py#L65), we should change those arguments. A similar issue can be found [here](https://github.com/huggingface/alignment-handbook/issues/203)