### PR TITLE
fix: easier environment setup; pin `trl`, `transformers`, `math-verify`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ uv venv openr1 --python 3.11 && source openr1/bin/activate && uv pip install --u
 Next, install vLLM:
 
 ```shell
-uv pip install vllm>=0.7.0
+uv pip install vllm>=0.7.1
 
 # For CUDA 12.1
-pip install vllm>=0.7.0 --extra-index-url https://download.pytorch.org/whl/cu121
+pip install vllm>=0.7.1 --extra-index-url https://download.pytorch.org/whl/cu121
 export LD_LIBRARY_PATH=$(python -c "import site; print(site.getsitepackages()[0] + '/nvidia/nvjitlink/lib')"):$LD_LIBRARY_PATH
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,23 +45,47 @@ We will use the DeepSeek-R1 [tech report](https://github.com/deepseek-ai/DeepSee
 
 **Note: Libraries rely on CUDA 12.1. Double check your system if you get segmentation faults.**
 
-To run the code in this project, first, create a Python virtual environment using e.g. `uv`.
-To install `uv`, follow the [UV Installation Guide](https://docs.astral.sh/uv/getting-started/installation/).
+First, create a virtual environment, either with Conda or `uv`.
 
+### Using `conda`
+
+Use your existing venv or create a new one with:
+
+```shell
+conda create -n openr1 python=3.11
+```
+
+### Using `uv`
+
+To install `uv`, follow the [UV Installation Guide](https://docs.astral.sh/uv/getting-started/installation/).
 
 ```shell
 uv venv openr1 --python 3.11 && source openr1/bin/activate && uv pip install --upgrade pip
 ```
 
-Next, install vLLM:
+### Dependencies
+
+From here, the easiest way to get started is to run:
 
 ```shell
-uv pip install vllm>=0.7.1
-
-# For CUDA 12.1
-pip install vllm>=0.7.1 --extra-index-url https://download.pytorch.org/whl/cu121
-export LD_LIBRARY_PATH=$(python -c "import site; print(site.getsitepackages()[0] + '/nvidia/nvjitlink/lib')"):$LD_LIBRARY_PATH
+./setup.sh
 ```
+
+OR, do it manually:
+<details>
+<summary>Bash</summary>
+
+```shell
+# Install pinned vllm
+pip install "vllm>=0.7.1" --extra-index-url https://download.pytorch.org/whl/cu121
+
+# nvJitLink
+export LD_LIBRARY_PATH=$(python -c "import site; print(site.getsitepackages()[0] + '/nvidia/nvjitlink/lib')"):$LD_LIBRARY_PATH
+
+# Install dependencies
+pip install -e ".[dev]"
+```
+</details>
 
 This will also install PyTorch `v2.5.1` and it is **very important** to use this version since the vLLM binaries are compiled for it. You can then install the remaining dependencies for your specific use case via `pip install -e .[LIST OF MODES]`. For most contributors, we recommend:
 

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ _deps = [
     "torch>=2.5.1",
     "transformers @ git+https://github.com/huggingface/transformers.git@main",
     "trl @ git+https://github.com/huggingface/trl.git@main",
-    "vllm>=0.7.0",
+    "vllm>=0.7.1",
     "wandb>=0.19.1",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -61,8 +61,8 @@ _deps = [
     "safetensors>=0.3.3",
     "sentencepiece>=0.1.99",
     "torch>=2.5.1",
-    "transformers @ git+https://github.com/huggingface/transformers.git@main",
-    "trl @ git+https://github.com/huggingface/trl.git@main",
+    "transformers>=4.48.2",
+    "trl>=0.14.0",
     "vllm>=0.7.1",
     "wandb>=0.19.1",
 ]

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ _deps = [
     "pytest",
     "safetensors>=0.3.3",
     "sentencepiece>=0.1.99",
-    "torch>=2.5.1",
+    "torch==2.5.1",
     "transformers>=4.48.2",
     "trl>=0.14.0",
     "vllm>=0.7.1",

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+REQUIRED_PREFIX="12.1"
+CUDA_FULL_VERSION=$(nvcc --version | grep "release" | awk '{print $6}' | cut -c2-)
+
+# Only stable for CUDA 12.1 right now.
+if [[ "$CUDA_FULL_VERSION" != ${REQUIRED_PREFIX}* ]]; then
+  echo "Error: CUDA version starting with $REQUIRED_PREFIX is required, but found CUDA version $CUDA_FULL_VERSION."
+  exit 1
+fi
+
+echo "---"
+echo "Using CUDA $CUDA_FULL_VERSION"
+
+echo "---"
+echo "Setting up vllm and nvJitLink."
+pip install "vllm>=0.7.1" --extra-index-url https://download.pytorch.org/whl/cu121 2>&1
+export LD_LIBRARY_PATH=$(python -c "import site; print(site.getsitepackages()[0] + '/nvidia/nvjitlink/lib')"):$LD_LIBRARY_PATH
+
+echo "---"
+echo "Installing dependencies."
+pip install -e ".[dev]"
+
+echo "---"
+echo "Finished setup. GRPO example (expects 8 accelerators):
+
+    HF_HUB_ENABLE_HF_TRANSFER=1 ACCELERATE_LOG_LEVEL=info accelerate launch \\
+        --config_file recipes/accelerate_configs/zero3.yaml \\
+        --num_processes=7 \\
+        src/open_r1/grpo.py \\
+        --config recipes/qwen/Qwen2.5-1.5B-Instruct/grpo/confg_full.yaml
+"


### PR DESCRIPTION
`trl`/`transformers` versions pinned (thanks to @yeshsurya for the note): 
- Fixes #145
- Fixes #146

Includes `lighteval`/`math-verify` version bump from https://github.com/huggingface/open-r1/pull/193.

`setup.sh` has been tested on a clean Debian CUDA 12.1 with GRPO example, 8x H100. Easier to run, prints out the example command for the user, and shorter README section.