### PR TITLE
Fix README: Correct recipes path and missing --config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ accelerate launch --config_file=recipes/accelerate_configs/zero3.yaml src/open_r
 
 # Train via YAML config
 accelerate launch --config_file recipes/accelerate_configs/zero3.yaml src/open_r1/sft.py \
-    recipes/Qwen2.5-1.5B-Instruct/sft/config_demo.yaml
+    --config recipes/Qwen2.5-1.5B-Instruct/sft/config_demo.yaml
 ```
 
 Currently, the following tasks are supported:

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ By default, these scripts will push each model to your Hugging Face Hub username
 ```shell
 # Change batch size, number of epochs etc
 accelerate launch --config_file recipes/accelerate_configs/zero3.yaml src/open_r1/sft.py \
-    recipes/Qwen/Qwen2.5-1.5B-Instruct/sft/config_demo.yaml
+    --config recipes/Qwen2.5-1.5B-Instruct/sft/config_demo.yaml
     --per_device_train_batch_size=1 --num_train_epochs=5
 ```
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ accelerate launch --config_file=recipes/accelerate_configs/zero3.yaml src/open_r
 
 # Train via YAML config
 accelerate launch --config_file recipes/accelerate_configs/zero3.yaml src/open_r1/sft.py \
-    recipes/Qwen/Qwen2.5-1.5B-Instruct/sft/config_demo.yaml
+    recipes/Qwen2.5-1.5B-Instruct/sft/config_demo.yaml
 ```
 
 Currently, the following tasks are supported:


### PR DESCRIPTION
This PR fixes two issues in the training command in **README.md**:

1. Incorrect path: Adjusted the path to match the actual folder structure.
2. Missing --config flag: Added --config before the YAML file.