### PR TITLE
Fix AIME25 naming

### DIFF
--- a/src/open_r1/evaluate.py
+++ b/src/open_r1/evaluate.py
@@ -106,8 +106,9 @@ aime24 = LightevalTaskConfig(
     metric=[expr_gold_metric],
     version=1,
 )
-aime25 = LightevalTaskConfig(
-    name="aime25",
+# Part I from AIME 2025 exam: https://artofproblemsolving.com/wiki/index.php/2025_AIME_I?srsltid=AfmBOoof5gaaqlt3-l6LH7Tt6qmJZtl_2PQEDYlLFlMqhq9dLL8FMCRR
+aime25_part1 = LightevalTaskConfig(
+    name="aime25:part1",
     suite=["custom"],
     prompt_function=aime_prompt_fn,
     hf_repo="open-r1/aime_2025_1",
@@ -155,7 +156,7 @@ gpqa_diamond = LightevalTaskConfig(
 # Add tasks to the table
 TASKS_TABLE = []
 TASKS_TABLE.append(aime24)
-TASKS_TABLE.append(aime25)
+TASKS_TABLE.append(aime25_part1)
 TASKS_TABLE.append(math_500)
 TASKS_TABLE.append(gpqa_diamond)
 

--- a/src/open_r1/utils/evaluation.py
+++ b/src/open_r1/utils/evaluation.py
@@ -48,7 +48,7 @@ LIGHTEVAL_TASKS = {}
 
 register_lighteval_task(LIGHTEVAL_TASKS, "custom", "math_500", "math_500", 0)
 register_lighteval_task(LIGHTEVAL_TASKS, "custom", "aime24", "aime24", 0)
-register_lighteval_task(LIGHTEVAL_TASKS, "custom", "aime25", "aime25", 0)
+register_lighteval_task(LIGHTEVAL_TASKS, "custom", "aime25_I", "aime25:I", 0)
 register_lighteval_task(LIGHTEVAL_TASKS, "custom", "gpqa", "gpqa:diamond", 0)
 
 

--- a/src/open_r1/utils/evaluation.py
+++ b/src/open_r1/utils/evaluation.py
@@ -48,7 +48,7 @@ LIGHTEVAL_TASKS = {}
 
 register_lighteval_task(LIGHTEVAL_TASKS, "custom", "math_500", "math_500", 0)
 register_lighteval_task(LIGHTEVAL_TASKS, "custom", "aime24", "aime24", 0)
-register_lighteval_task(LIGHTEVAL_TASKS, "custom", "aime25_I", "aime25:I", 0)
+register_lighteval_task(LIGHTEVAL_TASKS, "custom", "aime25_part1", "aime25:part1", 0)
 register_lighteval_task(LIGHTEVAL_TASKS, "custom", "gpqa", "gpqa:diamond", 0)
 
 


### PR DESCRIPTION
I just realised that only part 1 of AIME25 has been released and the second set will come out next week. To align with `aime24` (which is the full set of 30 questions), I've renamed the eval for AIME25 until the full set is available