### PR TITLE
Fix: Default value of `cosine_min_value_wrong` parameter

### DIFF
--- a/src/open_r1/grpo.py
+++ b/src/open_r1/grpo.py
@@ -67,7 +67,7 @@ class GRPOScriptArguments(ScriptArguments):
         },
     )
     cosine_min_value_wrong: float = field(
-        default=0.0,
+        default=-1.0,
         metadata={"help": "Minimum reward for wrong answers"},
     )
     cosine_max_value_wrong: float = field(


### PR DESCRIPTION
According to the semantics of the parameter name, min_value should be smaller than max_value, but the original default value does not meet this point and is inconsistent with the correct default value of the `get_cosine_scaled_reward` function in rewards.py.
```python
def get_cosine_scaled_reward(
    min_value_wrong: float = -1.0,
    ...
):
...
```

In the `get_cosine_scaled_reward` function, min_value and max_value will be exchanged when the question is wrong:
```python
if is_correct:
    min_value = min_value_correct
    max_value = max_value_correct
else:
    # Swap min/max for incorrect answers
    min_value = max_value_wrong
    max_value = min_value_wrong

reward = min_value + 0.5 * (max_value - min_value) * (1.0 + cosine)
```
Then in the formula `max_value - min_value`, the correct default value will get a negative value, but using the current default value will get a positive value, so that the shorter the wrong question is, the higher the score will be. This is inconsistent with the description of `Longer incorrect solutions are penalized less than shorter ones.` in the `get_cosine_scaled_reward` function comment.