### PR TITLE
Pin training dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if stale_egg_info.exists():
 # IMPORTANT: all dependencies should be listed here with their version requirements, if any.
 #   * If a dependency is fast-moving (e.g. trl), pin to the exact version
 _deps = [
-    "accelerate>=1.2.1",
+    "accelerate==1.4.0",
     "bitsandbytes>=0.43.0",
     "datasets>=3.2.0",
     "deepspeed==0.15.4",
@@ -49,7 +49,6 @@ _deps = [
     "e2b-code-interpreter>=1.0.5",
     "einops>=0.8.0",
     "flake8>=6.0.0",
-    "flash_attn>=2.7.4.post1",
     "hf_transfer>=0.1.4",
     "huggingface-hub[cli]>=0.19.2,<1.0",
     "isort>=5.12.0",
@@ -67,8 +66,8 @@ _deps = [
     "safetensors>=0.3.3",
     "sentencepiece>=0.1.99",
     "torch==2.5.1",
-    "transformers @ git+https://github.com/huggingface/transformers.git@main",
-    "trl @ git+https://github.com/huggingface/trl.git@main",
+    "transformers==4.49.0",
+    "trl @ git+https://github.com/huggingface/trl.git@013d360b8f2703d3546786fa124f3204d6cd8018",
     "vllm==0.7.2",
     "wandb>=0.19.1",
 ]


### PR DESCRIPTION
To ensure consistency across training runs, let's pin the core deps and update them incrementally.