### PR TITLE
Align format reward with R1 traces and add reward function to count think / answer tags

### DIFF
--- a/recipes/DeepSeek-R1-Distill-Qwen-1.5B/grpo/config_demo.yaml
+++ b/recipes/DeepSeek-R1-Distill-Qwen-1.5B/grpo/config_demo.yaml
@@ -48,7 +48,9 @@ report_to:
 reward_funcs:
 - accuracy
 - format
+- tag_count
 reward_weights:
+- 1.0
 - 1.0
 - 1.0
 save_strategy: "epoch"

--- a/recipes/Qwen2.5-1.5B-Instruct/grpo/config_demo.yaml
+++ b/recipes/Qwen2.5-1.5B-Instruct/grpo/config_demo.yaml
@@ -44,7 +44,9 @@ report_to:
 reward_funcs:
 - accuracy
 - format
+- tag_count
 reward_weights:
+- 1.0
 - 1.0
 - 1.0
 save_strategy: "epoch"

--- a/src/open_r1/grpo.py
+++ b/src/open_r1/grpo.py
@@ -70,7 +70,7 @@ class GRPOScriptArguments(ScriptArguments):
     reward_funcs: list[str] = field(
         default_factory=lambda: ["accuracy", "format", "tag_count"],
         metadata={
-            "help": "List of reward functions. Possible values: 'accuracy', 'format', 'format_deepseek', 'reasoning_steps', 'cosine', 'repetition_penalty', 'length', 'code', 'code_format'"
+            "help": "List of reward functions. Possible values: 'accuracy', 'format', 'format_deepseek', 'reasoning_steps', 'cosine', 'repetition_penalty', 'length', tag_count', 'code', 'code_format'"
         },
     )
     cosine_min_value_wrong: float = field(

--- a/src/open_r1/grpo.py
+++ b/src/open_r1/grpo.py
@@ -34,6 +34,7 @@ from open_r1.rewards import (
     get_repetition_penalty_reward,
     len_reward,
     reasoning_steps_reward,
+    tag_count_reward,
 )
 from open_r1.utils import get_tokenizer
 from open_r1.utils.callbacks import get_callbacks
@@ -51,7 +52,7 @@ class GRPOScriptArguments(ScriptArguments):
 
     Args:
         reward_funcs (`list[str]`):
-            List of reward functions. Possible values: 'accuracy', 'format', 'format_deepseek', 'reasoning_steps', 'cosine', 'repetition_penalty', 'length'.
+            List of reward functions. Possible values: 'accuracy', 'format', 'format_deepseek', 'reasoning_steps', 'cosine', 'repetition_penalty', 'length', tag_count', 'code', 'code_format'.
         cosine_min_value_wrong (`float`):
             Minimum reward for cosine scaling for wrong answers.
         cosine_max_value_wrong (`float`):
@@ -67,7 +68,7 @@ class GRPOScriptArguments(ScriptArguments):
     """
 
     reward_funcs: list[str] = field(
-        default_factory=lambda: ["accuracy", "format"],
+        default_factory=lambda: ["accuracy", "format", "tag_count"],
         metadata={
             "help": "List of reward functions. Possible values: 'accuracy', 'format', 'format_deepseek', 'reasoning_steps', 'cosine', 'repetition_penalty', 'length', 'code', 'code_format'"
         },
@@ -174,6 +175,7 @@ def main(script_args, training_args, model_args):
         "length": len_reward,
         "code": code_reward,
         "code_format": get_code_format_reward(language=script_args.code_language),
+        "tag_count": tag_count_reward,
     }
     reward_funcs = [REWARD_FUNCS_REGISTRY[func] for func in script_args.reward_funcs]
 

--- a/src/open_r1/rewards.py
+++ b/src/open_r1/rewards.py
@@ -77,13 +77,13 @@ def tag_count_reward(completions, **kwargs) -> list[float]:
     def count_tags(text: str) -> float:
         count = 0.0
         if text.count("<think>\n") == 1:
-            count += 0.125
+            count += 0.25
         if text.count("\n</think>\n") == 1:
-            count += 0.125
+            count += 0.25
         if text.count("\n<answer>\n") == 1:
-            count += 0.125
+            count += 0.25
         if text.count("\n</answer>") == 1:
-            count += 0.125
+            count += 0.25
         return count
 
     contents = [completion[0]["content"] for completion in completions]

--- a/src/open_r1/rewards.py
+++ b/src/open_r1/rewards.py
@@ -62,10 +62,32 @@ def accuracy_reward(completions, solution, **kwargs):
 
 def format_reward(completions, **kwargs):
     """Reward function that checks if the reasoning process is enclosed within <think> and </think> tags, while the final answer is enclosed within <answer> and </answer> tags."""
-    pattern = r"^<think>.*?</think>\s*<answer>.*?</answer>$"
+    pattern = r"^<think>\n.*?\n</think>\n<answer>\n.*?\n</answer>$"
     completion_contents = [completion[0]["content"] for completion in completions]
     matches = [re.match(pattern, content, re.DOTALL | re.MULTILINE) for content in completion_contents]
     return [1.0 if match else 0.0 for match in matches]
+
+
+def tag_count_reward(completions, **kwargs) -> list[float]:
+    """Reward function that checks if we produce the desired number of think and answer tags associated with `format_reward()`.
+
+    Adapted from: https://gist.github.com/willccbb/4676755236bb08cab5f4e54a0475d6fb#file-grpo_demo-py-L90
+    """
+
+    def count_tags(text: str) -> float:
+        count = 0.0
+        if text.count("<think>\n") == 1:
+            count += 0.125
+        if text.count("\n</think>\n") == 1:
+            count += 0.125
+        if text.count("\n<answer>\n") == 1:
+            count += 0.125
+        if text.count("\n</answer>") == 1:
+            count += 0.125
+        return count
+
+    contents = [completion[0]["content"] for completion in completions]
+    return [count_tags(c) for c in contents]
 
 
 def reasoning_steps_reward(completions, **kwargs):
@@ -366,7 +388,7 @@ def get_code_format_reward(language: str = "python"):
     Args:
         language: Programming language supported by E2B https://e2b.dev/docs/code-interpreting/supported-languages
     """
-    pattern = rf"^<think>.*?</think>\s*<answer>.*?```{language}\n.*?```.*?</answer>$"
+    pattern = rf"^<think>\n.*?\n</think>\n<answer>\n.*?```{language}.*?```.*?\n</answer>$"
 
     def code_format_reward(completions, **kwargs):
         completion_contents = [completion[0]["content"] for completion in completions]

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -30,7 +30,7 @@ class TestRewards(unittest.TestCase):
 
     def test_format_reward_correct(self):
         """Test format_reward with correct format."""
-        completion = [[{"content": "<think>Some reasoning</think><answer>The answer</answer>"}]]
+        completion = [[{"content": "<think>\nSome reasoning\n</think>\n<answer>\nThe answer\n</answer>"}]]
         rewards = format_reward(completion)
         self.assertEqual(rewards[0], 1.0)
 
@@ -107,7 +107,7 @@ class TestRewards(unittest.TestCase):
 
     def test_format_reward_specific_multiline(self):
         """Test format_reward with a specific multiline input."""
-        inputs = "<think>\nI will count each distinct object in the image:\n1. Purple scooter\n2. Red bicycle\n3. Green motorcycle\n4. Gray sedan\n5. Yellow school bus\n6. Small green double-decker bus\n7. Small red car\n8. Small purple car\n9. Small gray dirt bike\n\nThere are 9 distinct objects in total.\n</think>\n<answer>9</answer>"
+        inputs = "<think>\nI will count each distinct object in the image:\n1. Purple scooter\n2. Red bicycle\n3. Green motorcycle\n4. Gray sedan\n5. Yellow school bus\n6. Small green double-decker bus\n7. Small red car\n8. Small purple car\n9. Small gray dirt bike\n\nThere are 9 distinct objects in total.\n</think>\n<answer>\n9\n</answer>"
         completion = [[{"content": inputs}]]
         rewards = format_reward(completion)
         self.assertEqual(rewards[0], 1.0)
@@ -320,7 +320,7 @@ class TestCodeFormat(unittest.TestCase):
         completion = [
             [
                 {
-                    "content": "<think>Let's solve this\nStep 1: First step</think>\n<answer>```python\ndef hello():\n    print('world')\n```</answer>"
+                    "content": "<think>\nLet's solve this\nStep 1: First step\n</think>\n<answer>\n```python\ndef hello():\n    print('world')\n```\n</answer>"
                 }
             ]
         ]
@@ -354,7 +354,7 @@ class TestCodeFormat(unittest.TestCase):
         completion = [
             [
                 {
-                    "content": "<think>Here's an example:\n```python\nx = 1\n```\nNow the solution:</think>\n<answer>```python\ndef solution():\n    return 42\n```</answer>"
+                    "content": "<think>\nHere's an example:\n```python\nx = 1\n```\nNow the solution:\n</think>\n<answer>\n```python\ndef solution():\n    return 42\n```\n</answer>"
                 }
             ]
         ]
@@ -365,7 +365,11 @@ class TestCodeFormat(unittest.TestCase):
     def test_different_languages(self):
         """Test code format reward with different programming languages."""
         completion = [
-            [{"content": "<think>Analysis</think><answer>```javascript\nconsole.log('hello');\n```</answer>"}]
+            [
+                {
+                    "content": "<think>\nAnalysis\n</think>\n<answer>\n```javascript\nconsole.log('hello');\n```\n</answer>"
+                }
+            ]
         ]
 
         # Test with JavaScript
@@ -383,7 +387,7 @@ class TestCodeFormat(unittest.TestCase):
         completion = [
             [
                 {
-                    "content": "<think>Here's the analysis</think>\n<answer>```python\nclass Solution:\n    def __init__(self):\n        self.value = 42\n        \n    def get_value(self):\n        return self.value\n```</answer>"
+                    "content": "<think>\nHere's the analysis\n</think>\n<answer>\n```python\nclass Solution:\n    def __init__(self):\n        self.value = 42\n        \n    def get_value(self):\n        return self.value\n```\n</answer>"
                 }
             ]
         ]

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -8,6 +8,7 @@ from open_r1.rewards import (
     get_repetition_penalty_reward,
     len_reward,
     reasoning_steps_reward,
+    tag_count_reward,
 )
 
 
@@ -312,6 +313,42 @@ class TestRepetitionPenaltyReward(unittest.TestCase):
 
         rewards = reward_fn(completions)
         self.assertEqual(rewards, [0.0])
+
+    def test_tag_count_rewards_all_correct(self):
+        """Test tag_count_reward with correct tags."""
+        completion = [[{"content": "<think>\nSome reasoning\n</think>\n<answer>\nThe answer\n</answer>"}]]
+        rewards = tag_count_reward(completion)
+        self.assertEqual(rewards[0], 1.0)
+
+    def test_tag_count_rewards_missing_think_begin(self):
+        """Test tag_count_reward with missing <think> tag."""
+        completion = [[{"content": "Some reasoning\n</think>\n<answer>\nThe answer\n</answer>"}]]
+        rewards = tag_count_reward(completion)
+        self.assertEqual(rewards[0], 0.75)
+
+    def test_tag_count_rewards_missing_think_end(self):
+        """Test tag_count_reward with missing </think> tag."""
+        completion = [[{"content": "<think>\nSome reasoning\n<answer>\nThe answer\n</answer>"}]]
+        rewards = tag_count_reward(completion)
+        self.assertEqual(rewards[0], 0.75)
+
+    def test_tag_count_rewards_missing_answer_begin(self):
+        """Test tag_count_reward with missing <answer> tag."""
+        completion = [[{"content": "<think>\nSome reasoning\n</think>\nThe answer\n</answer>"}]]
+        rewards = tag_count_reward(completion)
+        self.assertEqual(rewards[0], 0.75)
+
+    def test_tag_count_rewards_missing_answer_end(self):
+        """Test tag_count_reward with missing </answer> tag."""
+        completion = [[{"content": "<think>\nSome reasoning\n</think>\n<answer>\nThe answer"}]]
+        rewards = tag_count_reward(completion)
+        self.assertEqual(rewards[0], 0.75)
+
+    def test_tag_count_rewards_missing_all_tags(self):
+        """Test tag_count_reward with missing all tags."""
+        completion = [[{"content": "Some reasoning\nThe answer"}]]
+        rewards = tag_count_reward(completion)
+        self.assertEqual(rewards[0], 0.0)
 
 
 class TestCodeFormat(unittest.TestCase):


### PR DESCRIPTION
This PR aligns the format reward function to be closer to the traces from DeepSeek-R1, which have the following format:

```html
<think>
{thoughts}
</think>
{response}
```

To remain consistent with the `<answer>` and `</answer>` tags in the existing `format_reward()` function, the new format is now:

```html
<think>
{thoughts}
</think>
<answer>
{response}
</answer>
```

Our prior regex was softer since it didn't enforce line breaks, a detail that is somewhat important if you want your inference code to be consistent across models. Note that the tests had to be updated to accommodate this change.

I also noticed in some GRPO runs that the models can end up emitting multiple thought / answer blocks in a single completion which gives positive reward for the format, but is not ideal. To handle that, I've introduced a tag count function that is inspired from Will's GRPO demo: https://gist.github.com/willccbb/4676755236bb08cab5f4e54a0475d6fb