### PR TITLE
updates max_seq_length to max length due to a bug in trl

### DIFF
--- a/recipes/Mistral-Small-24B-Instruct-2501/sft/config_openr1_math.yaml
+++ b/recipes/Mistral-Small-24B-Instruct-2501/sft/config_openr1_math.yaml
@@ -29,7 +29,7 @@ logging_steps: 1
 logging_strategy: steps
 lr_scheduler_type: cosine
 packing: true
-max_seq_length: 32768
+max_length: 32768
 max_steps: -1
 num_train_epochs: 5
 output_dir: data/Mistral-Small-24B-Instruct-2501-Open-R1-Distill

--- a/recipes/OpenR1-Qwen-7B/sft/config.yaml
+++ b/recipes/OpenR1-Qwen-7B/sft/config.yaml
@@ -13,7 +13,7 @@ dataset_configs:
 dataset_num_proc: 48
 
 #SFT hyperparam
-max_seq_length: 32768
+max_length: 32768
 weight_decay: 0.0001
 optim: adamw_torch
 lr_scheduler_type: linear

--- a/recipes/Qwen2.5-1.5B-Instruct/sft/config_demo.yaml
+++ b/recipes/Qwen2.5-1.5B-Instruct/sft/config_demo.yaml
@@ -28,7 +28,7 @@ lr_scheduler_type: cosine_with_min_lr
 lr_scheduler_kwargs:
   min_lr_rate: 0.1
 packing: true
-max_seq_length: 16384
+max_length: 16384
 max_steps: -1
 num_train_epochs: 1
 output_dir: data/Qwen2.5-1.5B-Open-R1-Distill


### PR DESCRIPTION
There was a bug in TRL which caused seq_length to default to 1024 even when `max_seq_length` (soft deprecated) was set to another value.

This PR updates our configs in case anyone is running experiments with the bugged version.

Fixed in TRL in PR  https://github.com/huggingface/trl/pull/2947