### PR TITLE
Flash Attention Padding Fix

### DIFF
--- a/src/open_r1/utils/model_utils.py
+++ b/src/open_r1/utils/model_utils.py
@@ -16,6 +16,7 @@ def get_tokenizer(
         model_args.model_name_or_path,
         revision=model_args.model_revision,
         trust_remote_code=model_args.trust_remote_code,
+        padding_side='left',
     )
 
     if training_args.chat_template is not None:


### PR DESCRIPTION
When I attempted to use the Qwen2.5 7B model for grpo training, I encountered an error: 
```bash
ValueError: You are attempting to perform batched generation with padding_side='right' this may lead to unexpected behaviour for Flash Attention version of Qwen2.
```
This issue can be resolved by replacing 'right' with 'left'.