### PR TITLE
Bump TRL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ _deps = [
     "sentencepiece>=0.1.99",
     "torch==2.5.1",
     "transformers==4.49.0",
-    "trl @ git+https://github.com/huggingface/trl.git@013d360b8f2703d3546786fa124f3204d6cd8018",
+    "trl @ git+https://github.com/huggingface/trl.git@69ad852e5654a77f1695eb4c608906fe0c7e8624",
     "vllm==0.7.2",
     "wandb>=0.19.1",
 ]


### PR DESCRIPTION
Bumps trl as there were a number of bug fixes for caching and seq_length. Should resolve https://github.com/huggingface/open-r1/issues/435