### PR TITLE
Resolve double BOS token issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ We use `lighteval` to evaluate models, with custom tasks defined in `src/open_r1
 
 ```shell
 MODEL=deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
-MODEL_ARGS="pretrained=$MODEL,dtype=bfloat16,max_model_length=32768,gpu_memory_utilization=0.8,generation_parameters={max_new_tokens:32768,temperature:0.6,top_p:0.95}"
+MODEL_ARGS="pretrained=$MODEL,dtype=bfloat16,max_model_length=32768,gpu_memory_utilization=0.8,add_special_tokens=false,generation_parameters={max_new_tokens:32768,temperature:0.6,top_p:0.95}"
 OUTPUT_DIR=data/evals/$MODEL
 
 # AIME 2024
@@ -310,7 +310,7 @@ To increase throughput across multiple GPUs, use _data parallel_ as follows:
 ```shell
 NUM_GPUS=8
 MODEL=deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
-MODEL_ARGS="pretrained=$MODEL,dtype=bfloat16,data_parallel_size=$NUM_GPUS,max_model_length=32768,gpu_memory_utilization=0.8,generation_parameters={max_new_tokens:32768,temperature:0.6,top_p:0.95}"
+MODEL_ARGS="pretrained=$MODEL,dtype=bfloat16,data_parallel_size=$NUM_GPUS,max_model_length=32768,gpu_memory_utilization=0.8,add_special_tokens=false,generation_parameters={max_new_tokens:32768,temperature:0.6,top_p:0.95}"
 TASK=aime24
 OUTPUT_DIR=data/evals/$MODEL
 
@@ -325,7 +325,7 @@ For large models which require sharding across GPUs, use _tensor parallel_ and r
 ```shell
 NUM_GPUS=8
 MODEL=deepseek-ai/DeepSeek-R1-Distill-Qwen-32B
-MODEL_ARGS="pretrained=$MODEL,dtype=bfloat16,tensor_parallel_size=$NUM_GPUS,max_model_length=32768,gpu_memory_utilization=0.8,generation_parameters={max_new_tokens:32768,temperature:0.6,top_p:0.95}"
+MODEL_ARGS="pretrained=$MODEL,dtype=bfloat16,tensor_parallel_size=$NUM_GPUS,max_model_length=32768,gpu_memory_utilization=0.8,add_special_tokens=false,generation_parameters={max_new_tokens:32768,temperature:0.6,top_p:0.95}"
 TASK=aime24
 OUTPUT_DIR=data/evals/$MODEL
 


### PR DESCRIPTION
When using chat template, the BOS token is automatically added to the context. This PR disables adding of the second BOS token, which at the moment happens automatically when the context passes through tokenizer's call which by default is called with `add_special_tokens=True` (ref: https://github.com/huggingface/lighteval/blob/ed084813e0bd12d82a06d9f913291fdbee774905/src/lighteval/models/vllm/vllm_model.py#L90).

Before this PR, inputs to the model would look like this:
```bash
[[151646, 151646, 151644, 50, 3948, 279, 2701 ...
<｜begin▁of▁sentence｜><｜begin▁of▁sentence｜><｜User｜>Solve the following ...
```

After this PR, inputs to the model would look like this:
```bash
[[151646, 151644, 50, 3948, 279, 2701 ...
<｜begin▁of▁sentence｜><｜User｜>Solve the following ...
```

Important Note: Right now, there is no support in `lighteval` to parse this argument from string input into boolean representation, so this PR will have effect ones https://github.com/huggingface/lighteval/pull/598 is merged.
