### PR TITLE
Run e2b async sandbox by default

### DIFF
--- a/src/open_r1/rewards.py
+++ b/src/open_r1/rewards.py
@@ -14,7 +14,7 @@ from .utils import is_e2b_available
 
 if is_e2b_available():
     from dotenv import load_dotenv
-    from e2b_code_interpreter import AsyncSandbox, Sandbox
+    from e2b_code_interpreter import AsyncSandbox
 
     load_dotenv()
 

--- a/src/open_r1/rewards.py
+++ b/src/open_r1/rewards.py
@@ -1,5 +1,6 @@
 """Reward functions for GRPO training."""
 
+import asyncio
 import json
 import math
 import re
@@ -13,7 +14,7 @@ from .utils import is_e2b_available
 
 if is_e2b_available():
     from dotenv import load_dotenv
-    from e2b_code_interpreter import Sandbox
+    from e2b_code_interpreter import Sandbox, AsyncSandbox
 
     load_dotenv()
 
@@ -316,10 +317,12 @@ def extract_code(completion: str) -> str:
     return extracted_answer
 
 
-def code_reward(completions, **kwargs) -> list[float]:
+def code_reward(completions, run_sync: bool = False, **kwargs) -> list[float]:
     """Reward function that evaluates code snippets using the E2B code interpreter.
 
     Assumes the dataset contains a `verification_info` column with test cases.
+
+    Set run_sync=True to run with a synchronous e2b Sandbox, by default it will run asynchronously.
     """
     if not is_e2b_available():
         raise ImportError(
@@ -329,60 +332,58 @@ def code_reward(completions, **kwargs) -> list[float]:
 
     rewards = []
     # TODO: add support for other languages in E2B: https://e2b.dev/docs/code-interpreting/supported-languages
-    try:
-        """Returns a reward function that evaluates code snippets in a sandbox."""
-        evaluation_script_template = """
-        import subprocess
-        import json
+    """Returns a reward function that evaluates code snippets in a sandbox."""
+    evaluation_script_template = """
+    import subprocess
+    import json
 
-        def evaluate_code(code, test_cases):
-            passed = 0
-            total = len(test_cases)
-            exec_timeout = 5
+    def evaluate_code(code, test_cases):
+        passed = 0
+        total = len(test_cases)
+        exec_timeout = 5
 
-            for case in test_cases:
-                process = subprocess.run(
-                    ["python3", "-c", code],
-                    input=case["input"],
-                    text=True,
-                    capture_output=True,
-                    timeout=exec_timeout
-                )
-
-                if process.returncode != 0:  # Error in execution
-                    continue
-
-                output = process.stdout.strip()
-                if output.strip() == case["output"].strip():
-                    passed += 1
-
-            success_rate = (passed / total)
-            return success_rate
-
-        code_snippet = {code}
-        test_cases = json.loads({test_cases})
-
-        evaluate_code(code_snippet, test_cases)
-        """
-        code_snippets = [extract_code(completion[-1]["content"]) for completion in completions]
-        verification_info = kwargs["verification_info"]
-        scripts = [
-            evaluation_script_template.format(
-                code=json.dumps(code), test_cases=json.dumps(json.dumps(info["test_cases"]))
+        for case in test_cases:
+            process = subprocess.run(
+                ["python3", "-c", code],
+                input=case["input"],
+                text=True,
+                capture_output=True,
+                timeout=exec_timeout
             )
-            for code, info in zip(code_snippets, verification_info)
-        ]
-        with Sandbox(timeout=30, request_timeout=3) as sbx:
-            for script in scripts:
-                execution = sbx.run_code(script, language=verification_info["language"])
-                try:
-                    output = float(execution.text)
-                except (TypeError, ValueError):
-                    output = 0.0
-                rewards.append(output)
+
+            if process.returncode != 0:  # Error in execution
+                continue
+
+            output = process.stdout.strip()
+            if output.strip() == case["output"].strip():
+                passed += 1
+
+        success_rate = (passed / total)
+        return success_rate
+
+    code_snippet = {code}
+    test_cases = json.loads({test_cases})
+
+    evaluate_code(code_snippet, test_cases)
+    """
+    code_snippets = [extract_code(completion[-1]["content"]) for completion in completions]
+    verification_info = kwargs["verification_info"]
+    scripts = [
+        evaluation_script_template.format(
+            code=json.dumps(code), test_cases=json.dumps(json.dumps(info["test_cases"]))
+        )
+        for code, info in zip(code_snippets, verification_info)
+    ]
+    try:
+        if run_sync:
+            rewards = run_sync(scripts, verification_info["language"])
+        else:
+            rewards = run_async_from_sync(scripts, verification_info["language"])
+            
     except Exception as e:
         print(f"Error from E2B executor: {e}")
         rewards = [0.0] * len(completions)
+
     return rewards
 
 
@@ -400,3 +401,59 @@ def get_code_format_reward(language: str = "python"):
         return [1.0 if match else 0.0 for match in matches]
 
     return code_format_reward
+
+
+def run_sync(scripts: list[str], language: str) -> list[float]:
+    """Synchronous version of e2b.Sanbox. """
+    rewards = []
+    with Sandbox(timeout=30, request_timeout=3) as sbx:
+        for script in scripts:
+            execution = sbx.run_code(script, language=verification_info["language"])
+            try:
+                output = float(execution.text)
+            except (TypeError, ValueError):
+                output = 0.0
+            rewards.append(output)
+    return rewards
+
+
+def run_async_from_sync(scripts: list[str], language: str) -> list[float]:
+    """Function wrapping the `run_async` function, an async version
+    of `run_sync`.
+    """
+    # Create a new event loop and set it
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    
+    try:
+        # Run the async function and get the result
+        rewards = loop.run_until_complete(run_async(scripts, language))
+    finally:
+        loop.close()
+    
+    return rewards
+
+
+async def run_async(scripts: list[str], language: str):
+    # Create the sandbox by hand, currently there's no context manager for this version
+    sbx = await AsyncSandbox.create(timeout=30, request_timeout=3)
+
+    # Create a list of tasks for running scripts concurrently
+    tasks = [run_script(sbx, script) for script in scripts]
+
+    # Wait for all tasks to complete and gather their results as they finish
+    results = await asyncio.gather(*tasks)
+    rewards = list(results)  # collect results
+
+    # Kill the sandbox after all the tasks are complete
+    await sbx.kill()
+
+    return rewards
+
+
+async def run_script(sbx, script: str, language: str) -> float:
+    execution = await sbx.run_code(script, language=language)
+    try:
+        return float(execution.text)
+    except (TypeError, ValueError):
+        return 0.0

--- a/src/open_r1/rewards.py
+++ b/src/open_r1/rewards.py
@@ -330,7 +330,6 @@ def code_reward(completions, run_sync: bool = False, **kwargs) -> list[float]:
             "`pip install e2b-code-interpreter` and add an API key to a `.env` file."
         )
 
-    rewards = []
     # TODO: add support for other languages in E2B: https://e2b.dev/docs/code-interpreting/supported-languages
     """Returns a reward function that evaluates code snippets in a sandbox."""
     evaluation_script_template = """

--- a/src/open_r1/rewards.py
+++ b/src/open_r1/rewards.py
@@ -14,7 +14,7 @@ from .utils import is_e2b_available
 
 if is_e2b_available():
     from dotenv import load_dotenv
-    from e2b_code_interpreter import Sandbox, AsyncSandbox
+    from e2b_code_interpreter import AsyncSandbox, Sandbox
 
     load_dotenv()
 
@@ -368,9 +368,7 @@ def code_reward(completions, run_sync: bool = False, **kwargs) -> list[float]:
     code_snippets = [extract_code(completion[-1]["content"]) for completion in completions]
     verification_info = kwargs["verification_info"]
     scripts = [
-        evaluation_script_template.format(
-            code=json.dumps(code), test_cases=json.dumps(json.dumps(info["test_cases"]))
-        )
+        evaluation_script_template.format(code=json.dumps(code), test_cases=json.dumps(json.dumps(info["test_cases"])))
         for code, info in zip(code_snippets, verification_info)
     ]
     try:
@@ -378,7 +376,7 @@ def code_reward(completions, run_sync: bool = False, **kwargs) -> list[float]:
             rewards = run_sync(scripts, verification_info["language"])
         else:
             rewards = run_async_from_sync(scripts, verification_info["language"])
-            
+
     except Exception as e:
         print(f"Error from E2B executor: {e}")
         rewards = [0.0] * len(completions)
@@ -403,7 +401,7 @@ def get_code_format_reward(language: str = "python"):
 
 
 def run_sync(scripts: list[str], language: str) -> list[float]:
-    """Synchronous version of e2b.Sanbox. """
+    """Synchronous version of e2b.Sanbox."""
     rewards = []
     with Sandbox(timeout=30, request_timeout=3) as sbx:
         for script in scripts:
@@ -423,13 +421,13 @@ def run_async_from_sync(scripts: list[str], language: str) -> list[float]:
     # Create a new event loop and set it
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    
+
     try:
         # Run the async function and get the result
         rewards = loop.run_until_complete(run_async(scripts, language))
     finally:
         loop.close()
-    
+
     return rewards
 
 

--- a/src/open_r1/rewards.py
+++ b/src/open_r1/rewards.py
@@ -407,7 +407,7 @@ def run_sync(scripts: list[str], language: str) -> list[float]:
     rewards = []
     with Sandbox(timeout=30, request_timeout=3) as sbx:
         for script in scripts:
-            execution = sbx.run_code(script, language=verification_info["language"])
+            execution = sbx.run_code(script, language=language)
             try:
                 output = float(execution.text)
             except (TypeError, ValueError):


### PR DESCRIPTION
## Description

Refactor of `src/open_r1/rewards.py` `code_reward` function to allow running concurrent test cases. The original version can be recovered by passing `code_reward(completions, run_sync=True)` (set to False by default).