### PR TITLE
FIX: Three Bugs in async E2B code sandbox

### DIFF
--- a/src/open_r1/rewards.py
+++ b/src/open_r1/rewards.py
@@ -428,7 +428,7 @@ async def run_async(scripts: list[str], languages: list[str]) -> list[float]:
 
 async def run_script(sbx, script: str, language: str) -> float:
     try:
-        execution = await sbx.run_code(script, language=language)
+        execution = await sbx.run_code(script, language=language, timeout=30)
     except Exception as e:
         print(f"Error from E2B executor: {e}")
         return 0.0


### PR DESCRIPTION
The previous implementation and #484 on async E2B sandbox have three bugs.

First in this line, `verification_info` is actually a list. See the list comprehension right above.
https://github.com/huggingface/open-r1/blob/9890a8d9921ecf27784a18896f3b974b357df903/src/open_r1/rewards.py#L373

Here also screenshot from pdb:
<img width="1148" alt="Screenshot 2025-03-09 at 00 21 23" src="https://github.com/user-attachments/assets/d3d25dbb-b982-4519-a854-d438c34227eb" />

Fixed by collecting `languages` first and from then on passing `languages: list[str]` around.



Second bug is `language` was not passed to `run_script`.
https://github.com/huggingface/open-r1/blob/9890a8d9921ecf27784a18896f3b974b357df903/src/open_r1/rewards.py#L418
Even though it expects `language`.
https://github.com/huggingface/open-r1/blob/9890a8d9921ecf27784a18896f3b974b357df903/src/open_r1/rewards.py#L430

Third bug: see comment below.

I also added more specific error handling, as exceptions of these three bugs were handle too generally.