### PR TITLE
sft learn to generate eos token

### DIFF
--- a/src/open_r1/sft.py
+++ b/src/open_r1/sft.py
@@ -106,7 +106,8 @@ def main(script_args, training_args, model_args):
     # Load tokenizer
     ################
     tokenizer = get_tokenizer(model_args, training_args)
-    tokenizer.pad_token = tokenizer.eos_token
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
 
     ###################
     # Model init kwargs


### PR DESCRIPTION
Avoid 'eos_token' from being labeled as -100 and stopping contribute to loss. 
one-line changing in sft.py. 
correlated issue: https://github.com/huggingface/open-r1/issues/492