### PR TITLE
add ddp_timeout argument in SFTConfig to avoid timeout error(issue #160)

### DIFF
--- a/src/open_r1/configs.py
+++ b/src/open_r1/configs.py
@@ -83,3 +83,9 @@ class SFTConfig(trl.SFTConfig):
         default=None,
         metadata={"help": ("The project to store runs under.")},
     )
+    ddp_timeout: Optional[int] = field(
+        default=3600*24,
+        metadata={
+            "help": "Overrides the default timeout for distributed training (value should be given in seconds)."
+        },
+    )


### PR DESCRIPTION
add `ddp_timeout` argument in SFTConfig to avoid timeout error(issue #160)