### PR TITLE
Fixing the default of dataset_prompt_column

### DIFF
--- a/src/open_r1/configs.py
+++ b/src/open_r1/configs.py
@@ -162,6 +162,6 @@ class GRPOScriptArguments(trl.ScriptArguments):
     )
 
     dataset_prompt_column: str = field(
-        default="prompt",
+        default="problem",
         metadata={"help": "Column to use as prompts for training."},
     )


### PR DESCRIPTION
A recent update introduced the `dataset_prompt_column` argument to fix errors when a dataset's `question` field is not `problem`. However, this change unintentionally broke the default behavior for most example datasets, which do use the `problem` field. To maintain compatibility, the default value should be set to `problem` instead of `prompt`.