### PR TITLE
Add WandB groups to logging

### DIFF
--- a/src/open_r1/configs.py
+++ b/src/open_r1/configs.py
@@ -50,6 +50,10 @@ class GRPOConfig(trl.GRPOConfig):
         default=None,
         metadata={"help": ("The project to store runs under.")},
     )
+    wandb_run_group: Optional[str] = field(
+        default=None,
+        metadata={"help": ("The group to store runs under.")},
+    )
 
 
 @dataclass
@@ -82,6 +86,10 @@ class SFTConfig(trl.SFTConfig):
     wandb_project: Optional[str] = field(
         default=None,
         metadata={"help": ("The project to store runs under.")},
+    )
+    wandb_run_group: Optional[str] = field(
+        default=None,
+        metadata={"help": ("The group to store runs under.")},
     )
 
 

--- a/src/open_r1/utils/wandb_logging.py
+++ b/src/open_r1/utils/wandb_logging.py
@@ -9,3 +9,5 @@ def init_wandb_training(training_args):
         os.environ["WANDB_ENTITY"] = training_args.wandb_entity
     if training_args.wandb_project is not None:
         os.environ["WANDB_PROJECT"] = training_args.wandb_project
+    if training_args.wandb_run_group is not None:
+        os.environ["WANDB_RUN_GROUP"] = training_args.wandb_run_group


### PR DESCRIPTION
Adds support to specify `--wandb_run_group` in training runs so e.g. a batch of runs can be grouped together like this: https://wandb.ai/huggingface/open-r1/groups/r1-zero-qwen-7b/workspace?nw=nwuserlewtun