### PR TITLE
Fix eval system prompt

### DIFF
--- a/slurm/evaluate.slurm
+++ b/slurm/evaluate.slurm
@@ -50,7 +50,7 @@ lighteval vllm "$MODEL_ARGS" $TASKS \
     --use-chat-template \
     --output-dir $OUTPUT_DIR \
     --save-details \
-    ${7:+--system-prompt "$7"}
+    ${7:+--system-prompt "$(echo "$7" | base64 --decode)"}
 
 OUTPUT_FILEPATHS=$(find $OUTPUT_DIR/results/ -type f \( -name "*.json" \))
 for filepath in $OUTPUT_FILEPATHS; do

--- a/src/open_r1/utils/evaluation.py
+++ b/src/open_r1/utils/evaluation.py
@@ -7,8 +7,9 @@ from .hub import get_gpu_count_for_vllm, get_param_count_from_repo_id
 if TYPE_CHECKING:
     from trl import GRPOConfig, SFTConfig, ModelConfig
 
-import os
 import base64
+import os
+
 
 # We need a special environment setup to launch vLLM from within Slurm training jobs.
 # - Reference code: https://github.com/huggingface/brrr/blob/c55ba3505686d690de24c7ace6487a5c1426c0fd/brrr/lighteval/one_job_runner.py#L105

--- a/src/open_r1/utils/evaluation.py
+++ b/src/open_r1/utils/evaluation.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from trl import GRPOConfig, SFTConfig, ModelConfig
 
 import os
-
+import base64
 
 # We need a special environment setup to launch vLLM from within Slurm training jobs.
 # - Reference code: https://github.com/huggingface/brrr/blob/c55ba3505686d690de24c7ace6487a5c1426c0fd/brrr/lighteval/one_job_runner.py#L105
@@ -88,7 +88,10 @@ def run_lighteval_job(
         f"{model_args.trust_remote_code}",
     ]
     if training_args.system_prompt is not None:
-        cmd_args.append(f"--system_prompt={training_args.system_prompt}")
+        # encode to base64 to avoid issues with special characters
+        # we decode in the sbatch script
+        prompt_encoded = base64.b64encode(training_args.system_prompt.encode()).decode()
+        cmd_args.append(prompt_encoded)
     cmd[-1] += " " + " ".join(cmd_args)
     subprocess.run(cmd, check=True)
 


### PR DESCRIPTION
When we launch the evals, the command includes `bash -c ...`, it seems that this does not play well with special characters. 

This PR encodes the system prompt in base64, then decodes it in the sbatch script, as a workaround to the issue.