### PR TITLE
Fix SFT for base models

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,45 @@ accelerate launch --config_file recipes/accelerate_configs/zero3.yaml src/open_r
     --wandb_entity huggingface --wandb_project open-r1 --run_name Qwen2.5-1.5B-GRPO
 ```
 
+**🚨 WARNING 🚨**
+
+Most base models like `meta-llama/Llama-3.2-1B` do not have a chat template, so we set ChatML as the default during training. However, for Qwen base models like `Qwen/Qwen2.5-1.5B`, a chat template is pre-defined in the tokenizer, so the EOS token must be set accordingly, e.g.
+
+```diff
+# Align EOS token with chat template for Qwen base models
+accelerate launch --config_file=recipes/accelerate_configs/zero3.yaml src/open_r1/sft.py \
+    --model_name_or_path Qwen/Qwen2.5-1.5B \
++   --eos_token '<|im_end|>'
+    --dataset_name open-r1/OpenR1-Math-220k \
+    --learning_rate 5.0e-5 \
+    --num_train_epochs 1 \
+    --max_seq_length 16384 \
+    --per_device_train_batch_size 16 \
+    --gradient_checkpointing \
+    --bf16 \
+    --use_liger_kernel \
+    --output_dir data/Qwen2.5-1.5B-Open-R1-Distill
+```
+
+If you wish to use a custom chat template (e.g. Llama or Gemma), then the chat template and associated EOS token must be provided:
+
+```diff
+# Align EOS token with custom chat template
+accelerate launch --config_file=recipes/accelerate_configs/zero3.yaml src/open_r1/sft.py \
+    --model_name_or_path meta-llama/Llama-3.2-1B \
++   --chat_template "$(cat llama_chat_template.jinja)" \
++   --eos_token '<|eot_id|>' \
+    --dataset_name open-r1/OpenR1-Math-220k \
+    --learning_rate 5.0e-5 \
+    --num_train_epochs 1 \
+    --max_seq_length 16384 \
+    --per_device_train_batch_size 16 \
+    --gradient_checkpointing \
+    --bf16 \
+    --use_liger_kernel \
+    --output_dir data/Llama-3.2-1B-Open-R1-Distill
+```
+
 ### SFT
 
 To run SFT on a dataset distilled from DeepSeek-R1 with reasoning traces such as [open-r1/OpenR1-Math-220k](https://huggingface.co/datasets/open-r1/OpenR1-Math-220k), run:

--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ accelerate launch --config_file=recipes/accelerate_configs/zero3.yaml src/open_r
     --dataset_name open-r1/OpenR1-Math-220k \
     --learning_rate 5.0e-5 \
     --num_train_epochs 1 \
-    --packing \
     --max_seq_length 16384 \
     --per_device_train_batch_size 16 \
     --gradient_checkpointing \

--- a/recipes/OpenR1-Qwen-7B/sft/config.yaml
+++ b/recipes/OpenR1-Qwen-7B/sft/config.yaml
@@ -36,7 +36,7 @@ hub_strategy: every_save
 log_level: info
 logging_steps: 5
 logging_strategy: steps
-packing: true
+packing: false
 output_dir: data/OpenR1-Qwen-7B-SFT
 overwrite_output_dir: true
 push_to_hub: true

--- a/recipes/Qwen2.5-1.5B-Instruct/sft/config_demo.yaml
+++ b/recipes/Qwen2.5-1.5B-Instruct/sft/config_demo.yaml
@@ -25,7 +25,7 @@ logging_strategy: steps
 lr_scheduler_type: cosine_with_min_lr
 lr_scheduler_kwargs:
   min_lr_rate: 0.1
-packing: true
+packing: false
 max_length: 16384
 max_steps: -1
 num_train_epochs: 1

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ _deps = [
     "sentencepiece>=0.1.99",
     "torch==2.6.0",
     "transformers==4.51.2",
-    "trl @ git+https://github.com/huggingface/trl.git@d625c5533a6b1c84d3565c8080857f6bb81c538a",  # Bump for vLLM and 2x faster throughput: https://github.com/huggingface/trl/pull/3276
+    "trl @ git+https://github.com/huggingface/trl.git@c04e84c4545acfaecdf7e0631ad07a86ab0fb2f6",  # Fix EOS token for SFT on base models: https://github.com/huggingface/trl/pull/3299
     "vllm==0.8.3",
     "wandb>=0.19.1",
 ]

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _deps = [
     "accelerate==1.4.0",
     "bitsandbytes>=0.43.0",
     "datasets>=3.2.0",
-    "deepspeed==0.15.4",
+    "deepspeed==0.16.4",
     "distilabel[vllm,ray,openai]>=1.5.2",
     "e2b-code-interpreter>=1.0.5",
     "einops>=0.8.0",

--- a/src/open_r1/sft.py
+++ b/src/open_r1/sft.py
@@ -20,9 +20,10 @@ Usage:
 # One 1 node of 8 x H100s
 accelerate launch --config_file=recipes/accelerate_configs/zero3.yaml src/open_r1/sft.py \
     --model_name_or_path Qwen/Qwen2.5-1.5B-Instruct \
-    --dataset_name HuggingFaceH4/Bespoke-Stratos-17k \
+    --dataset_name open-r1/OpenR1-Math-220k \
     --learning_rate 2.0e-5 \
     --num_train_epochs 1 \
+    --packing \
     --max_seq_length 4096 \
     --per_device_train_batch_size 2 \
     --gradient_accumulation_steps 8 \
@@ -39,25 +40,16 @@ import os
 import sys
 
 import datasets
-import torch
 import transformers
 from datasets import load_dataset
 from transformers import set_seed
 from transformers.trainer_utils import get_last_checkpoint
 
 from open_r1.configs import SFTConfig
-from open_r1.utils import get_tokenizer
+from open_r1.utils import get_model, get_tokenizer
 from open_r1.utils.callbacks import get_callbacks
 from open_r1.utils.wandb_logging import init_wandb_training
-from trl import (
-    ModelConfig,
-    ScriptArguments,
-    SFTTrainer,
-    TrlParser,
-    get_kbit_device_map,
-    get_peft_config,
-    get_quantization_config,
-)
+from trl import ModelConfig, ScriptArguments, SFTTrainer, TrlParser, get_peft_config, setup_chat_format
 
 
 logger = logging.getLogger(__name__)
@@ -107,29 +99,19 @@ def main(script_args, training_args, model_args):
     tokenizer = get_tokenizer(model_args, training_args)
 
     ###################
-    # Model init kwargs
+    # Load model
     ###################
-    logger.info("*** Initializing model kwargs ***")
-    torch_dtype = (
-        model_args.torch_dtype if model_args.torch_dtype in ["auto", None] else getattr(torch, model_args.torch_dtype)
-    )
-    quantization_config = get_quantization_config(model_args)
-    model_kwargs = dict(
-        revision=model_args.model_revision,
-        trust_remote_code=model_args.trust_remote_code,
-        attn_implementation=model_args.attn_implementation,
-        torch_dtype=torch_dtype,
-        use_cache=False if training_args.gradient_checkpointing else True,
-        device_map=get_kbit_device_map() if quantization_config is not None else None,
-        quantization_config=quantization_config,
-    )
-    training_args.model_init_kwargs = model_kwargs
+    logger.info("*** Loading model ***")
+    model = get_model(model_args, training_args)
+
+    if tokenizer.chat_template is None:
+        model, tokenizer = setup_chat_format(model, tokenizer, format="chatml")
 
     ############################
     # Initialize the SFT Trainer
     ############################
     trainer = SFTTrainer(
-        model=model_args.model_name_or_path,
+        model=model,
         args=training_args,
         train_dataset=dataset[script_args.dataset_train_split],
         eval_dataset=dataset[script_args.dataset_test_split] if training_args.eval_strategy != "no" else None,

--- a/src/open_r1/sft.py
+++ b/src/open_r1/sft.py
@@ -105,6 +105,7 @@ def main(script_args, training_args, model_args):
     model = get_model(model_args, training_args)
 
     if tokenizer.chat_template is None:
+        logger.info("No chat template provided, using ChatML.")
         model, tokenizer = setup_chat_format(model, tokenizer, format="chatml")
 
     ############################

--- a/src/open_r1/sft.py
+++ b/src/open_r1/sft.py
@@ -23,7 +23,6 @@ accelerate launch --config_file=recipes/accelerate_configs/zero3.yaml src/open_r
     --dataset_name HuggingFaceH4/Bespoke-Stratos-17k \
     --learning_rate 2.0e-5 \
     --num_train_epochs 1 \
-    --packing \
     --max_seq_length 4096 \
     --per_device_train_batch_size 2 \
     --gradient_accumulation_steps 8 \
@@ -106,7 +105,6 @@ def main(script_args, training_args, model_args):
     # Load tokenizer
     ################
     tokenizer = get_tokenizer(model_args, training_args)
-    tokenizer.pad_token = tokenizer.eos_token
 
     ###################
     # Model init kwargs

--- a/src/open_r1/utils/__init__.py
+++ b/src/open_r1/utils/__init__.py
@@ -1,5 +1,5 @@
 from .import_utils import is_e2b_available
-from .model_utils import get_tokenizer
+from .model_utils import get_model, get_tokenizer
 
 
-__all__ = ["get_tokenizer", "is_e2b_available"]
+__all__ = ["get_tokenizer", "is_e2b_available", "get_model"]

--- a/src/open_r1/utils/model_utils.py
+++ b/src/open_r1/utils/model_utils.py
@@ -1,6 +1,7 @@
-from transformers import AutoTokenizer, PreTrainedTokenizer
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedTokenizer
 
-from trl import ModelConfig
+from trl import ModelConfig, get_kbit_device_map, get_quantization_config
 
 from ..configs import GRPOConfig, SFTConfig
 
@@ -20,7 +21,27 @@ def get_tokenizer(
 
     if training_args.chat_template is not None:
         tokenizer.chat_template = training_args.chat_template
-    elif auto_set_chat_template and tokenizer.get_chat_template() is None:
-        tokenizer.chat_template = DEFAULT_CHAT_TEMPLATE
 
     return tokenizer
+
+
+def get_model(model_args: ModelConfig, training_args: SFTConfig | GRPOConfig) -> AutoModelForCausalLM:
+    """Get the model"""
+    torch_dtype = (
+        model_args.torch_dtype if model_args.torch_dtype in ["auto", None] else getattr(torch, model_args.torch_dtype)
+    )
+    quantization_config = get_quantization_config(model_args)
+    model_kwargs = dict(
+        revision=model_args.model_revision,
+        trust_remote_code=model_args.trust_remote_code,
+        attn_implementation=model_args.attn_implementation,
+        torch_dtype=torch_dtype,
+        use_cache=False if training_args.gradient_checkpointing else True,
+        device_map=get_kbit_device_map() if quantization_config is not None else None,
+        quantization_config=quantization_config,
+    )
+    model = AutoModelForCausalLM.from_pretrained(
+        model_args.model_name_or_path,
+        **model_kwargs,
+    )
+    return model

--- a/src/open_r1/utils/model_utils.py
+++ b/src/open_r1/utils/model_utils.py
@@ -6,12 +6,7 @@ from trl import ModelConfig, get_kbit_device_map, get_quantization_config
 from ..configs import GRPOConfig, SFTConfig
 
 
-DEFAULT_CHAT_TEMPLATE = "{% for message in messages %}\n{% if message['role'] == 'user' %}\n{{ '<|user|>\n' + message['content'] + eos_token }}\n{% elif message['role'] == 'system' %}\n{{ '<|system|>\n' + message['content'] + eos_token }}\n{% elif message['role'] == 'assistant' %}\n{{ '<|assistant|>\n'  + message['content'] + eos_token }}\n{% endif %}\n{% if loop.last and add_generation_prompt %}\n{{ '<|assistant|>' }}\n{% endif %}\n{% endfor %}"
-
-
-def get_tokenizer(
-    model_args: ModelConfig, training_args: SFTConfig | GRPOConfig, auto_set_chat_template: bool = True
-) -> PreTrainedTokenizer:
+def get_tokenizer(model_args: ModelConfig, training_args: SFTConfig | GRPOConfig) -> PreTrainedTokenizer:
     """Get the tokenizer for the model."""
     tokenizer = AutoTokenizer.from_pretrained(
         model_args.model_name_or_path,


### PR DESCRIPTION
Fixes https://github.com/huggingface/open-r1/issues/603 https://github.com/huggingface/open-r1/issues/556 https://github.com/huggingface/open-r1/issues/520 https://github.com/huggingface/open-r1/issues/515 https://github.com/huggingface/open-r1/pull/494


This PR fixes several issues associated **unbounded generation** after applying SFT on **base** models. The reason we never ran into this internally is because we have thus far applied SFT on **instruct** models where (a) a chat template is defined and (b) the EOS token is aligned with the chat template.

Below I list out the 3 main cases I saw in various issues and provide the corresponding solution. Note that one must bump `trl` to make use of these fixes.

## Case 1: base model has a pre-defined chat template
Models like`Qwen/Qwen2.5-1.5B` have a [pre-defined chat template](https://huggingface.co/Qwen/Qwen2.5-1.5B/blob/main/tokenizer_config.json#L198) (ChatML). As a result, running SFT on Qwen models would format the `messages` in ChatML (as expected), but the EOS token of the SFT model was misaligned: it remained the same as the base model's `<|endoftext|>` instead of ChatML's `<|im_end|>`. 

### Solution:

Specify the chat template's EOS token as follows:

```diff
ACCELERATE_LOG_LEVEL=info TRANSFORMERS_VERBOSITY=info accelerate launch --config_file recipes/accelerate_configs/zero2.yaml src/open_r1/sft.py \
    --model_name_or_path Qwen/Qwen2.5-1.5B \
+   --eos_token '<|im_end|>' \
    --dataset_name trl-lib/Capybara \
    --learning_rate 2.0e-5 \
    --max_seq_length 2048 \
    --num_train_epochs 2 \
    --per_device_train_batch_size 16 \
    --gradient_accumulation_steps 1 \
    --gradient_checkpointing \
    --bf16 \
    --use_liger_kernel \
    --logging_steps 5 \
    --eval_strategy steps \
    --eval_steps 100 \
    --output_dir data/Qwen2.5-1.5B-SFT-Capybara-No-Packing \
    --push_to_hub
```

**Model:** https://huggingface.co/lewtun/Qwen2.5-1.5B-SFT-Capybara-No-Packing

Test inference with:

```shell
transformers-cli chat --model_name_or_path lewtun/Qwen2.5-1.5B-SFT-Capybara-No-Packing --do_sample --max_new_tokens 512
```

## Case 2: no chat template is specified

Models like `meta-llama/Llama-3.2-1B-Instruct` have no pre-defined chat template (the norm for most base models). As a result, unless the user set the `--chat_template` arg manually, the model would be trained without a chat template. 

### Solution
We now use `setup_chat_format()` which defaults to ChatML if the model does not have a chat template defined.

```shelll
ACCELERATE_LOG_LEVEL=info TRANSFORMERS_VERBOSITY=info accelerate launch --config_file recipes/accelerate_configs/zero2.yaml src/open_r1/sft.py \
    --model_name_or_path meta-llama/Llama-3.2-1B \
    --dataset_name trl-lib/Capybara \
    --learning_rate 2.0e-5 \
    --max_seq_length 2048 \
    --num_train_epochs 2 \
    --per_device_train_batch_size 16 \
    --gradient_accumulation_steps 1 \
    --gradient_checkpointing \
    --bf16 \
    --use_liger_kernel \
    --logging_steps 5 \
    --eval_strategy steps \
    --eval_steps 100 \
    --output_dir data/Llama-3.2-1B-SFT-Capybara-No-Packing-ChatML \
    --push_to_hub
```

**Model:** https://huggingface.co/lewtun/Llama-3.2-1B-SFT-Capybara-No-Packing-ChatML

Test inference with:

```shell
transformers-cli chat --model_name_or_path lewtun/Llama-3.2-1B-SFT-Capybara-No-Packing-ChatML --do_sample --max_new_tokens 512
```

## Case 3: custom chat template specified
If a user wished to use a chat template like Llama's, a similar issue as Case 1 occurs: there is a misalignment between the base model's EOS token `<|end_of_text|>` and the chat template's end of turn `<|eot_id|>`

### Solution
The user provides both the chat template and corresponding EOS token

```diff
ACCELERATE_LOG_LEVEL=info TRANSFORMERS_VERBOSITY=info accelerate launch --config_file recipes/accelerate_configs/zero2.yaml src/open_r1/sft.py \
    --model_name_or_path meta-llama/Llama-3.2-1B \
+   --chat_template "$(cat scratch/llama_chat_template.jinja)" \
+   --eos_token '<|eot_id|>' \
    --dataset_name trl-lib/Capybara \
    --learning_rate 2.0e-5 \
    --max_seq_length 2048 \
    --num_train_epochs 2 \
    --per_device_train_batch_size 16 \
    --gradient_accumulation_steps 1 \
    --gradient_checkpointing \
    --bf16 \
    --use_liger_kernel \
    --logging_steps 5 \
    --eval_strategy steps \
    --eval_steps 100 \
    --output_dir data/Llama-3.2-1B-SFT-Capybara-No-Packing-Llama \
    --push_to_hub
```

**Model** https://huggingface.co/lewtun/Llama-3.2-1B-SFT-Capybara-No-Packing-Llama

Test inference with:

```shell
transformers-cli chat --model_name_or_path lewtun/Llama-3.2-1B-SFT-Capybara-No-Packing-Llama --do_sample --max_new_tokens 512
```