### PR TITLE
Add dataset filtering script

### DIFF
--- a/recipes/dataset_filtering/config_demo.yaml
+++ b/recipes/dataset_filtering/config_demo.yaml
@@ -1,0 +1,27 @@
+# Model arguments
+model_name_or_path: deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
+model_revision: main
+torch_dtype: bfloat16
+attn_implementation: flash_attention_2
+
+# Data training arguments
+# We edit the DeepSeek chat template to ensure (a) the reasoning block within <think> and </think> is included in the completion and (b) the <think> tag is not part of the prefill so that the format reward works
+chat_template: "{% if not add_generation_prompt is defined %}{% set add_generation_prompt = false %}{% endif %}{% set ns = namespace(is_first=false, is_tool=false, is_output_first=true, system_prompt='') %}{%- for message in messages %}{%- if message['role'] == 'system' %}{% set ns.system_prompt = message['content'] %}{%- endif %}{%- endfor %}{{bos_token}}{{ns.system_prompt}}{%- for message in messages %}{%- if message['role'] == 'user' %}{%- set ns.is_tool = false -%}{{'<｜User｜>' + message['content']}}{%- endif %}{%- if message['role'] == 'assistant' and message['content'] is none %}{%- set ns.is_tool = false -%}{%- for tool in message['tool_calls']%}{%- if not ns.is_first %}{{'<｜Assistant｜><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\\n' + '```json' + '\\n' + tool['function']['arguments'] + '\\n' + '```' + '<｜tool▁call▁end｜>'}}{%- set ns.is_first = true -%}{%- else %}{{'\\n' + '<｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\\n' + '```json' + '\\n' + tool['function']['arguments'] + '\\n' + '```' + '<｜tool▁call▁end｜>'}}{{'<｜tool▁calls▁end｜><｜end▁of▁sentence｜>'}}{%- endif %}{%- endfor %}{%- endif %}{%- if message['role'] == 'assistant' and message['content'] is not none %}{%- if ns.is_tool %}{{'<｜tool▁outputs▁end｜>' + message['content'] + '<｜end▁of▁sentence｜>'}}{%- set ns.is_tool = false -%}{%- else %}{% set content = message['content'] %}{{'<｜Assistant｜>' + content + '<｜end▁of▁sentence｜>'}}{%- endif %}{%- endif %}{%- if message['role'] == 'tool' %}{%- set ns.is_tool = true -%}{%- if ns.is_output_first %}{{'<｜tool▁outputs▁begin｜><｜tool▁output▁begin｜>' + message['content'] + '<｜tool▁output▁end｜>'}}{%- set ns.is_output_first = false %}{%- else %}{{'\\n<｜tool▁output▁begin｜>' + message['content'] + '<｜tool▁output▁end｜>'}}{%- endif %}{%- endif %}{%- endfor -%}{% if ns.is_tool %}{{'<｜tool▁outputs▁end｜>'}}{% endif %}{% if add_generation_prompt and not ns.is_tool %}{{'<｜Assistant｜>'}}{% endif %}"
+dataset_name: open-r1/OpenR1-Math-220k
+dataset_prompt_column: problem
+system_prompt: "You are a helpful AI Assistant that provides well-reasoned and detailed responses. You first think about the reasoning process as an internal monologue and then provide the user with the answer. Respond in the following format: <think>\n...\n</think>\n<answer>\n...\n</answer>"
+
+# Generation arguments
+max_completion_length: 2048
+num_generations: 4
+temperature: 0.7
+
+# Reward func arguments
+reward_funcs:
+- accuracy
+reward_weights:
+- 1.0
+
+# Filtering arguments. Samples with mean reward outside of low / high will be filtered
+low_reward_threshold: 0.2
+high_reward_threshold: 0.8

--- a/scripts/filter_dataset.py
+++ b/scripts/filter_dataset.py
@@ -147,8 +147,7 @@ def main(script_args, training_args, model_args):
             
         return examples
         
-    dataset["train"] = dataset["train"].select(range(0, 1024))
-    dataset = dataset.map(batch_score, batched=True, batch_size=128)
+    dataset = dataset.map(batch_score, batched=True, batch_size=256)
     
     
     if script_args.output_dataset_name is not None:


### PR DESCRIPTION
This PR adds a script that generates `k` responses from a model and scores the reward using reward function(s).
The mean reward can be used to filter the dataset of easy and hard problems, which may improve GRPO performance.

Usage:

```shell
python scripts/filter_dataset.py --config recipes/dataset_filtering/config_demo.yaml
```

Example dataset, run on a 1k subset:

[OpenR1-Math-220k-generated](https://huggingface.co/datasets/open-r1/OpenR1-Math-220k-generated)

[OpenR1-Math-220k-generated-filtered](https://huggingface.co/datasets/open-r1/OpenR1-Math-220k-generated-filtered)

