### PR TITLE
Add time to Slurm

### DIFF
--- a/slurm/e2b_router.slurm
+++ b/slurm/e2b_router.slurm
@@ -6,6 +6,7 @@
 #SBATCH --output=/fsx/open-r1/logs/e2b_router/%x-%j.out
 #SBATCH --error=/fsx/open-r1/logs/e2b_router/%x-%j.err
 #SBATCH --requeue
+#SBATCH --time=7-00:00:00
 
 echo "Starting job"
 set -x -e

--- a/slurm/evaluate.slurm
+++ b/slurm/evaluate.slurm
@@ -5,6 +5,8 @@
 #SBATCH --output=./logs/%x-%j.out
 #SBATCH --error=./logs/%x-%j.err
 #SBATCH --requeue
+#SBATCH --time=1-00:00:00
+
 
 # Specific configuration optimized for the Hugging Face Compute Cluster
 # Be ye warned this may not work on other clusters!

--- a/slurm/morph_router.slurm
+++ b/slurm/morph_router.slurm
@@ -6,6 +6,8 @@
 #SBATCH --output=/fsx/open-r1/logs/morph_router/%x-%j.out
 #SBATCH --err=/fsx/open-r1/logs/morph_router/%x-%j.err
 #SBATCH --requeue
+#SBATCH --time=7-00:00:00
+
 
 echo "Starting job"
 set -x -e

--- a/slurm/train.slurm
+++ b/slurm/train.slurm
@@ -7,6 +7,8 @@
 #SBATCH --output=./logs/%x-%j.out
 #SBATCH --error=./logs/%x-%j.err
 #SBATCH --requeue
+#SBATCH --time=3-00:00:00
+
 
 if [[ "$*" == *"--help"* ]]; then
   echo "Usage: sbatch slurm/train.slurm [options]"


### PR DESCRIPTION
Add `--time` flag to comply with new HF Cluster requirements: https://huggingface.slack.com/archives/C04LMQCANLS/p1746797087651049

I only edited the Slurm files that did not have a preexisting `--time` flag set.