### PR TITLE
Add dataset mixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,10 +408,10 @@ To combine multiple datasets as a single training mixture, you can specify the `
 ```yaml
 dataset_mixture:
   datasets:                     # List of datasets to include in the mixture
-    - id: dataset_1
+    - id: dataset_1             # Hub dataset ID
       config: config_name_1     # Name of the dataset config
       split: split_1            # Split to use from the dataset
-      columns: [col1, col2]     # Columns to use from the dataset
+      columns: [col1, col2]     # Columns to keep
       weight: 0.25              # Fraction of dataset to use
     - id: dataset_2
       config: config_name_2
@@ -419,7 +419,7 @@ dataset_mixture:
       columns: [col1, col2]
       weight: 0.5
   seed: 42                      # Seed for shuffling the combined dataset
-  test_split_size: 0.1          # Fraction of the combined dataset to use for a test split
+  test_split_size: 0.1          # Fraction of mixture to use for a test split
 ```
 
 ## Evaluating models

--- a/README.md
+++ b/README.md
@@ -407,22 +407,20 @@ To combine multiple datasets as a single training mixture, you can specify the `
 
 ```yaml
 dataset_mixture:
-  datasets:
+  datasets:                 # List of datasets to include in the mixture
     - id: dataset_1
-      config: config_name_1
-      split: split_1
-      columns: [col1, col2]
-      weight: 0.25
+      config: config_name_1 # Name of the dataset config
+      split: split_1        # Split to use from the dataset
+      columns: [col1, col2] # Columns to use from the dataset
+      weight: 0.25          # Fraction of dataset to use
     - id: dataset_2
       config: config_name_2
       split: split_2
       columns: [col1, col2]
       weight: 0.5
-  seed: 42
-  test_split_size: 0.1
+  seed: 42                  # Seed for shuffling the combined dataset
+  test_split_size: 0.1      # Fraction of the combined dataset to use for a test split
 ```
-
-This will create a dataset mixture with two datasets, `dataset_1` and `dataset_2`, each with a different weight. The `columns` parameter specifies which columns to use from each dataset, and the `seed` parameter is used to shuffle the dataset before splitting it into training and test sets.
 
 ## Evaluating models
 

--- a/README.md
+++ b/README.md
@@ -407,19 +407,19 @@ To combine multiple datasets as a single training mixture, you can specify the `
 
 ```yaml
 dataset_mixture:
-  datasets:                 # List of datasets to include in the mixture
+  datasets:                     # List of datasets to include in the mixture
     - id: dataset_1
-      config: config_name_1 # Name of the dataset config
-      split: split_1        # Split to use from the dataset
-      columns: [col1, col2] # Columns to use from the dataset
-      weight: 0.25          # Fraction of dataset to use
+      config: config_name_1     # Name of the dataset config
+      split: split_1            # Split to use from the dataset
+      columns: [col1, col2]     # Columns to use from the dataset
+      weight: 0.25              # Fraction of dataset to use
     - id: dataset_2
       config: config_name_2
       split: split_2
       columns: [col1, col2]
       weight: 0.5
-  seed: 42                  # Seed for shuffling the combined dataset
-  test_split_size: 0.1      # Fraction of the combined dataset to use for a test split
+  seed: 42                      # Seed for shuffling the combined dataset
+  test_split_size: 0.1          # Fraction of the combined dataset to use for a test split
 ```
 
 ## Evaluating models

--- a/README.md
+++ b/README.md
@@ -245,7 +245,8 @@ sbatch --nodes=2 slurm/train.slurm --model Qwen2.5-1.5B-Instruct --task grpo --c
 
 See the [Launching jobs on a Slurm cluster](#launching-jobs-on-a-slurm-cluster) section for more details.
 
-### GRPO dataset filtering
+#### GRPO dataset filtering
+
 We provide support to filter datasets by generating and computing pass rate on veriable tasks, see this [README](scripts/pass_rate_filtering/README.md)
 
 #### 👨‍💻 Training with a code interpreter
@@ -399,6 +400,29 @@ sbatch --job-name=open_r1 --nodes=2 slurm/train.slurm --model Qwen2.5-1.5B-Instr
 
 > [!NOTE]
 > The configuration in `slurm/train.slurm` is optimised for the Hugging Face Compute Cluster and may require tweaking to be adapted to your own compute nodes.
+
+### Customising the dataset mixture
+
+To combine multiple datasets as a single training mixture, you can specify the `dataset_mixture` parameter in the YAML config file. Here's a template for how to do this:
+
+```yaml
+dataset_mixture:
+  datasets:
+    - id: dataset_1
+      config: config_name_1
+      split: split_1
+      columns: [col1, col2]
+      weight: 0.25
+    - id: dataset_2
+      config: config_name_2
+      split: split_2
+      columns: [col1, col2]
+      weight: 0.5
+  seed: 42
+  test_split_size: 0.1
+```
+
+This will create a dataset mixture with two datasets, `dataset_1` and `dataset_2`, each with a different weight. The `columns` parameter specifies which columns to use from each dataset, and the `seed` parameter is used to shuffle the dataset before splitting it into training and test sets.
 
 ## Evaluating models
 

--- a/README.md
+++ b/README.md
@@ -411,12 +411,16 @@ dataset_mixture:
     - id: dataset_1             # Hub dataset ID
       config: config_name_1     # Name of the dataset config
       split: split_1            # Split to use from the dataset
-      columns: [col1, col2]     # Columns to keep
+      columns:                  # Columns to keep
+        - column_1              
+        - column_2    
       weight: 0.25              # Fraction of dataset to use
     - id: dataset_2
       config: config_name_2
       split: split_2
-      columns: [col1, col2]
+      columns:                  
+        - column_1              
+        - column_2   
       weight: 0.5
   seed: 42                      # Seed for shuffling the combined dataset
   test_split_size: 0.1          # Fraction of mixture to use for a test split

--- a/src/open_r1/configs.py
+++ b/src/open_r1/configs.py
@@ -227,7 +227,7 @@ class GRPOScriptArguments(ScriptArguments):
     reward_funcs: list[str] = field(
         default_factory=lambda: ["accuracy", "format", "tag_count"],
         metadata={
-            "help": "list of reward functions. Possible values: 'accuracy', 'format', 'reasoning_steps', 'cosine', 'repetition_penalty', 'length', tag_count', 'code', 'code_format'"
+            "help": "List of reward functions. Possible values: 'accuracy', 'format', 'reasoning_steps', 'cosine', 'repetition_penalty', 'length', tag_count', 'code', 'code_format'"
         },
     )
     cosine_min_value_wrong: float = field(

--- a/src/open_r1/configs.py
+++ b/src/open_r1/configs.py
@@ -23,7 +23,7 @@ import trl
 class DatasetConfig:
     """Configuration for a dataset in a mixture."""
 
-    id: str  # Dataset identifier
+    id: str
     config: Optional[str] = None
     split: str = "train"
     columns: Optional[List[str]] = None

--- a/src/open_r1/configs.py
+++ b/src/open_r1/configs.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import trl
 
@@ -26,7 +26,7 @@ class DatasetConfig:
     id: str
     config: Optional[str] = None
     split: str = "train"
-    columns: Optional[List[str]] = None
+    columns: Optional[list[str]] = None
     weight: Optional[float] = None
 
 
@@ -34,7 +34,7 @@ class DatasetConfig:
 class DatasetMixtureConfig:
     """Configuration for a mixture of datasets."""
 
-    datasets: List[DatasetConfig]
+    datasets: list[DatasetConfig]
     seed: int = 0
     test_split_size: Optional[float] = None
 
@@ -45,7 +45,7 @@ class ScriptArguments(trl.ScriptArguments):
     Extended version of ScriptArguments with support for dataset mixtures.
 
     Args:
-        dataset_mixture (`Dict[str, Any]` or `None`, *optional*, defaults to `None`):
+        dataset_mixture (`dict[str, Any]` or `None`, *optional*, defaults to `None`):
             Configuration for creating dataset mixtures with advanced options.
             Format:
               dataset_mixture:
@@ -66,7 +66,7 @@ class ScriptArguments(trl.ScriptArguments):
     dataset_name: Optional[str] = field(
         default=None, metadata={"help": "Dataset name. Can be omitted if using dataset_mixture."}
     )
-    dataset_mixture: Optional[Dict[str, Any]] = field(
+    dataset_mixture: Optional[dict[str, Any]] = field(
         default=None,
         metadata={"help": "Configuration for creating dataset mixtures with advanced options like shuffling."},
     )
@@ -201,7 +201,7 @@ class GRPOScriptArguments(ScriptArguments):
 
     Args:
         reward_funcs (`list[str]`):
-            List of reward functions. Possible values: 'accuracy', 'format', 'reasoning_steps', 'cosine', 'repetition_penalty', 'length', 'tag_count', 'code', 'ioi_code', 'code_format', 'soft_overlong_punishment'.
+            list of reward functions. Possible values: 'accuracy', 'format', 'reasoning_steps', 'cosine', 'repetition_penalty', 'length', 'tag_count', 'code', 'ioi_code', 'code_format', 'soft_overlong_punishment'.
         cosine_min_value_wrong (`float`):
             Minimum reward for cosine scaling for wrong answers.
         cosine_max_value_wrong (`float`):
@@ -223,7 +223,7 @@ class GRPOScriptArguments(ScriptArguments):
     reward_funcs: list[str] = field(
         default_factory=lambda: ["accuracy", "format", "tag_count"],
         metadata={
-            "help": "List of reward functions. Possible values: 'accuracy', 'format', 'reasoning_steps', 'cosine', 'repetition_penalty', 'length', tag_count', 'code', 'code_format'"
+            "help": "list of reward functions. Possible values: 'accuracy', 'format', 'reasoning_steps', 'cosine', 'repetition_penalty', 'length', tag_count', 'code', 'code_format'"
         },
     )
     cosine_min_value_wrong: float = field(

--- a/src/open_r1/configs.py
+++ b/src/open_r1/configs.py
@@ -52,11 +52,15 @@ class ScriptArguments(trl.ScriptArguments):
                 datasets:
                   - id: dataset_id1
                     config: config_name
-                    columns: [col1, col2]
+                    columns:
+                      - col1
+                      - col2
                     weight: 0.5
                   - id: dataset_id2
                     config: config_name
-                    columns: [col1, col2]
+                    columns:
+                      - col1
+                      - col2
                     weight: 0.5
                 seed: 42
                 test_split_size: 0.1

--- a/src/open_r1/configs.py
+++ b/src/open_r1/configs.py
@@ -174,6 +174,10 @@ class SFTConfig(trl.SFTConfig):
         default=None,
         metadata={"help": ("The entity to store runs under.")},
     )
+    wandb_project: Optional[str] = field(
+        default=None,
+        metadata={"help": ("The project to store runs under.")},
+    )
     wandb_run_group: Optional[str] = field(
         default=None,
         metadata={"help": ("The group to store runs under.")},

--- a/src/open_r1/configs.py
+++ b/src/open_r1/configs.py
@@ -34,7 +34,7 @@ class DatasetConfig:
 class DatasetMixtureConfig:
     """Configuration for a mixture of datasets."""
 
-    datasets: List[DatasetConfig]  # Change from Dict to List
+    datasets: List[DatasetConfig]
     seed: int = 0
     test_split_size: Optional[float] = None
 
@@ -104,6 +104,16 @@ class ScriptArguments(trl.ScriptArguments):
                 seed=self.dataset_mixture.get("seed", 0),
                 test_split_size=self.dataset_mixture.get("test_split_size", None),
             )
+
+            # Check that column names are consistent across all dataset configs
+            columns_sets = [set(dataset.columns) for dataset in datasets_list if dataset.columns is not None]
+            if columns_sets:
+                first_columns = columns_sets[0]
+                if not all(columns == first_columns for columns in columns_sets):
+                    raise ValueError(
+                        "Column names must be consistent across all dataset configurations in a mixture. "
+                        f"Found different column sets: {[list(cols) for cols in columns_sets]}"
+                    )
 
 
 # TODO: add the shared options with a mixin to reduce code duplication

--- a/src/open_r1/configs.py
+++ b/src/open_r1/configs.py
@@ -205,7 +205,7 @@ class GRPOScriptArguments(ScriptArguments):
 
     Args:
         reward_funcs (`list[str]`):
-            list of reward functions. Possible values: 'accuracy', 'format', 'reasoning_steps', 'cosine', 'repetition_penalty', 'length', 'tag_count', 'code', 'ioi_code', 'code_format', 'soft_overlong_punishment'.
+            List of reward functions. Possible values: 'accuracy', 'format', 'reasoning_steps', 'cosine', 'repetition_penalty', 'length', 'tag_count', 'code', 'ioi_code', 'code_format', 'soft_overlong_punishment'.
         cosine_min_value_wrong (`float`):
             Minimum reward for cosine scaling for wrong answers.
         cosine_max_value_wrong (`float`):

--- a/src/open_r1/grpo.py
+++ b/src/open_r1/grpo.py
@@ -18,13 +18,12 @@ import sys
 
 import datasets
 import transformers
-from datasets import load_dataset
 from transformers import set_seed
 from transformers.trainer_utils import get_last_checkpoint
 
 from open_r1.configs import GRPOConfig, GRPOScriptArguments
 from open_r1.rewards import get_reward_funcs
-from open_r1.utils import get_model, get_tokenizer
+from open_r1.utils import get_dataset, get_model, get_tokenizer
 from open_r1.utils.callbacks import get_callbacks
 from open_r1.utils.wandb_logging import init_wandb_training
 from trl import GRPOTrainer, ModelConfig, TrlParser, get_peft_config
@@ -72,7 +71,7 @@ def main(script_args, training_args, model_args):
         init_wandb_training(training_args)
 
     # Load the dataset
-    dataset = load_dataset(script_args.dataset_name, name=script_args.dataset_config)
+    dataset = get_dataset(script_args)
 
     ################
     # Load tokenizer

--- a/src/open_r1/sft.py
+++ b/src/open_r1/sft.py
@@ -41,15 +41,14 @@ import sys
 
 import datasets
 import transformers
-from datasets import load_dataset
 from transformers import set_seed
 from transformers.trainer_utils import get_last_checkpoint
 
-from open_r1.configs import SFTConfig
-from open_r1.utils import get_model, get_tokenizer
+from open_r1.configs import ScriptArguments, SFTConfig
+from open_r1.utils import get_dataset, get_model, get_tokenizer
 from open_r1.utils.callbacks import get_callbacks
 from open_r1.utils.wandb_logging import init_wandb_training
-from trl import ModelConfig, ScriptArguments, SFTTrainer, TrlParser, get_peft_config, setup_chat_format
+from trl import ModelConfig, SFTTrainer, TrlParser, get_peft_config, setup_chat_format
 
 
 logger = logging.getLogger(__name__)
@@ -91,7 +90,7 @@ def main(script_args, training_args, model_args):
     ################
     # Load datasets
     ################
-    dataset = load_dataset(script_args.dataset_name, name=script_args.dataset_config)
+    dataset = get_dataset(script_args)
 
     ################
     # Load tokenizer

--- a/src/open_r1/utils/__init__.py
+++ b/src/open_r1/utils/__init__.py
@@ -1,5 +1,6 @@
+from .data import get_dataset
 from .import_utils import is_e2b_available, is_morph_available
 from .model_utils import get_model, get_tokenizer
 
 
-__all__ = ["get_tokenizer", "is_e2b_available", "is_morph_available", "get_model"]
+__all__ = ["get_tokenizer", "is_e2b_available", "is_morph_available", "get_model", "get_dataset"]

--- a/src/open_r1/utils/data.py
+++ b/src/open_r1/utils/data.py
@@ -1,8 +1,7 @@
 import logging
-from typing import Union
 
 import datasets
-from datasets import Dataset, DatasetDict, concatenate_datasets
+from datasets import DatasetDict, concatenate_datasets
 
 from ..configs import ScriptArguments
 
@@ -10,17 +9,14 @@ from ..configs import ScriptArguments
 logger = logging.getLogger(__name__)
 
 
-def get_dataset(
-    args: ScriptArguments,
-) -> Union[Dataset, DatasetDict]:
-    """
-    Load a dataset or a mixture of datasets based on the configuration.
+def get_dataset(args: ScriptArguments) -> DatasetDict:
+    """Load a dataset or a mixture of datasets based on the configuration.
 
     Args:
         args (ScriptArguments): Script arguments containing dataset configuration.
 
     Returns:
-        Dataset or DatasetDict: The loaded and processed dataset(s).
+        DatasetDict: The loaded datasets.
     """
     if args.dataset_name and not args.dataset_mixture:
         logger.info(f"Loading dataset: {args.dataset_name}")

--- a/src/open_r1/utils/data.py
+++ b/src/open_r1/utils/data.py
@@ -24,7 +24,7 @@ def get_dataset(
     """
     if args.dataset_name and not args.dataset_mixture:
         logger.info(f"Loading dataset: {args.dataset_name}")
-        return datasets.load_dataset(args.dataset_name, args.dataset_config_name)
+        return datasets.load_dataset(args.dataset_name, args.dataset_config)
     elif args.dataset_mixture:
         logger.info(f"Creating dataset mixture with {len(args.dataset_mixture.datasets)} datasets")
         seed = args.dataset_mixture.seed

--- a/src/open_r1/utils/data.py
+++ b/src/open_r1/utils/data.py
@@ -1,0 +1,96 @@
+from typing import Dict, List, Optional, Union
+import datasets
+from datasets import Dataset, DatasetDict, concatenate_datasets
+import logging
+import numpy as np
+
+from ..configs import DatasetConfig, ScriptArguments
+
+logger = logging.getLogger(__name__)
+
+def get_dataset(
+    args: ScriptArguments,
+) -> Union[Dataset, DatasetDict]:
+    """
+    Load a dataset or a mixture of datasets based on the configuration.
+    
+    Args:
+        args (ScriptArguments): Script arguments containing dataset configuration.
+    
+    Returns:
+        Dataset or DatasetDict: The loaded and processed dataset(s).
+    """
+    # Case 1: Using a single dataset
+    if args.dataset_name and not args.dataset_mixture:
+        logger.info(f"Loading dataset: {args.dataset_name}")
+        return datasets.load_dataset(args.dataset_name, args.dataset_config_name)
+        
+    # Case 2: Using a dataset mixture
+    elif args.dataset_mixture:
+        logger.info(f"Loading dataset mixture with {len(args.dataset_mixture)} datasets")
+        
+        # Dictionary to store datasets by split
+        mixture_by_split = {}
+        
+        # Process each dataset in the mixture
+        for dataset_name, dataset_config in args.dataset_mixture.items():
+            logger.info(f"Loading dataset for mixture: {dataset_name}")
+            
+            # Load the dataset
+            ds = datasets.load_dataset(
+                dataset_name,
+                dataset_config.config
+            )
+            dataset_split = dataset_config.split
+
+            if dataset_split in ds:
+                split_ds = ds[dataset_split]
+
+                # Filter columns if specified
+                if dataset_config.columns:
+                    split_ds = split_ds.select_columns(dataset_config.columns)
+
+                # Apply dataset weight as a sampling fraction
+                if dataset_config.weight < 1.0:
+                    # Calculate how many samples to keep
+                    n_samples = int(len(split_ds) * dataset_config.weight)
+                    if n_samples <= 0:
+                        logger.warning(
+                            f"Weight {dataset_config.weight} for dataset {dataset_name} "
+                            f"results in 0 samples. Using 1 sample instead."
+                        )
+                        n_samples = 1
+                    
+                    # Randomly sample the dataset
+                    indices = np.random.choice(
+                        len(split_ds), 
+                        size=n_samples, 
+                        replace=False
+                    )
+                    split_ds = split_ds.select(indices)
+                    
+                    logger.info(
+                        f"Applied weight {dataset_config.weight} to dataset {dataset_name}: "
+                        f"selected {n_samples} examples out of {len(ds[dataset_split])}"
+                    )
+                
+                # Add to the appropriate split in our mixture
+                if dataset_split not in mixture_by_split:
+                    mixture_by_split[dataset_split] = []
+                
+                mixture_by_split[dataset_split].append(split_ds)
+            else:
+                logger.warning(f"Split {dataset_split} not found in dataset {dataset_name}")
+        
+        # Concatenate datasets for each split
+        for split_name, datasets_list in mixture_by_split.items():
+            if datasets_list:
+                mixture_by_split[split_name] = concatenate_datasets(datasets_list)
+                logger.info(f"Created mixture for split '{split_name}' with {len(mixture_by_split[split_name])} examples")
+            else:
+                logger.warning(f"No datasets found for split {split_name}")
+        
+        return DatasetDict(mixture_by_split)
+    
+    else:
+        raise ValueError("Either dataset_name or dataset_mixture must be provided")

--- a/src/open_r1/utils/data.py
+++ b/src/open_r1/utils/data.py
@@ -1,96 +1,62 @@
-from typing import Dict, List, Optional, Union
+import logging
+from typing import Union
+
 import datasets
 from datasets import Dataset, DatasetDict, concatenate_datasets
-import logging
-import numpy as np
 
-from ..configs import DatasetConfig, ScriptArguments
+from ..configs import ScriptArguments
+
 
 logger = logging.getLogger(__name__)
+
 
 def get_dataset(
     args: ScriptArguments,
 ) -> Union[Dataset, DatasetDict]:
     """
     Load a dataset or a mixture of datasets based on the configuration.
-    
+
     Args:
         args (ScriptArguments): Script arguments containing dataset configuration.
-    
+
     Returns:
         Dataset or DatasetDict: The loaded and processed dataset(s).
     """
-    # Case 1: Using a single dataset
     if args.dataset_name and not args.dataset_mixture:
         logger.info(f"Loading dataset: {args.dataset_name}")
         return datasets.load_dataset(args.dataset_name, args.dataset_config_name)
-        
-    # Case 2: Using a dataset mixture
     elif args.dataset_mixture:
-        logger.info(f"Loading dataset mixture with {len(args.dataset_mixture)} datasets")
-        
-        # Dictionary to store datasets by split
-        mixture_by_split = {}
-        
-        # Process each dataset in the mixture
-        for dataset_name, dataset_config in args.dataset_mixture.items():
-            logger.info(f"Loading dataset for mixture: {dataset_name}")
-            
-            # Load the dataset
+        logger.info(f"Creating dataset mixture with {len(args.dataset_mixture.datasets)} datasets")
+
+        datasets_list = []
+
+        for dataset_config in args.dataset_mixture.datasets:
+            logger.info(f"Loading dataset for mixture: {dataset_config.id} (config: {dataset_config.config})")
             ds = datasets.load_dataset(
-                dataset_name,
-                dataset_config.config
+                dataset_config.id,
+                dataset_config.config,
+                split=dataset_config.split,
             )
-            dataset_split = dataset_config.split
+            if dataset_config.columns is not None:
+                ds = ds.select_columns(dataset_config.columns)
+            if dataset_config.weight is not None:
+                ds = ds.shuffle(seed=42).select(range(int(len(ds) * dataset_config.weight)))
+                logger.info(
+                    f"Subsampled dataset '{dataset_config.id}' (config: {dataset_config.config}) with weight={dataset_config.weight} to {len(ds)} examples"
+                )
 
-            if dataset_split in ds:
-                split_ds = ds[dataset_split]
+            datasets_list.append(ds)
 
-                # Filter columns if specified
-                if dataset_config.columns:
-                    split_ds = split_ds.select_columns(dataset_config.columns)
+        if datasets_list:
+            combined_dataset = concatenate_datasets(datasets_list)
+            if args.dataset_mixture.shuffle:
+                combined_dataset = combined_dataset.shuffle(seed=42)
+            logger.info(f"Created dataset mixture with {len(combined_dataset)} examples")
 
-                # Apply dataset weight as a sampling fraction
-                if dataset_config.weight < 1.0:
-                    # Calculate how many samples to keep
-                    n_samples = int(len(split_ds) * dataset_config.weight)
-                    if n_samples <= 0:
-                        logger.warning(
-                            f"Weight {dataset_config.weight} for dataset {dataset_name} "
-                            f"results in 0 samples. Using 1 sample instead."
-                        )
-                        n_samples = 1
-                    
-                    # Randomly sample the dataset
-                    indices = np.random.choice(
-                        len(split_ds), 
-                        size=n_samples, 
-                        replace=False
-                    )
-                    split_ds = split_ds.select(indices)
-                    
-                    logger.info(
-                        f"Applied weight {dataset_config.weight} to dataset {dataset_name}: "
-                        f"selected {n_samples} examples out of {len(ds[dataset_split])}"
-                    )
-                
-                # Add to the appropriate split in our mixture
-                if dataset_split not in mixture_by_split:
-                    mixture_by_split[dataset_split] = []
-                
-                mixture_by_split[dataset_split].append(split_ds)
-            else:
-                logger.warning(f"Split {dataset_split} not found in dataset {dataset_name}")
-        
-        # Concatenate datasets for each split
-        for split_name, datasets_list in mixture_by_split.items():
-            if datasets_list:
-                mixture_by_split[split_name] = concatenate_datasets(datasets_list)
-                logger.info(f"Created mixture for split '{split_name}' with {len(mixture_by_split[split_name])} examples")
-            else:
-                logger.warning(f"No datasets found for split {split_name}")
-        
-        return DatasetDict(mixture_by_split)
-    
+            # Return as a DatasetDict with a 'train' split
+            return DatasetDict({"train": combined_dataset})
+        else:
+            raise ValueError("No datasets were loaded from the mixture configuration")
+
     else:
-        raise ValueError("Either dataset_name or dataset_mixture must be provided")
+        raise ValueError("Either `dataset_name` or `dataset_mixture` must be provided")

--- a/tests/utils/test_data.py
+++ b/tests/utils/test_data.py
@@ -103,10 +103,26 @@ class TestGetDataset(unittest.TestCase):
         self.assertIn("prompt", dataset["train"].column_names)
         self.assertIn("chosen", dataset["train"].column_names)
 
+    def test_mixture_with_mismatched_columns(self):
+        dataset_configs = [
+            DatasetConfig(
+                id=self.dataset_name, config=self.dataset_config, split="train", columns=["prompt"], weight=None
+            ),
+            DatasetConfig(
+                id=self.dataset_name, config=self.dataset_config, split="train", columns=["chosen"], weight=None
+            ),
+        ]
+        dataset_mixture = DatasetMixtureConfig(
+            datasets=dataset_configs,
+        )
+        with self.assertRaises(ValueError) as context:
+            _ = ScriptArguments(dataset_mixture=asdict(dataset_mixture))
+        self.assertIn("Column names must be consistent", str(context.exception))
+
     def test_no_dataset_name_or_mixture(self):
-        with self.assertRaises(ValueError):
-            args = ScriptArguments(dataset_name=None, dataset_mixture=None)
-            get_dataset(args)
+        with self.assertRaises(ValueError) as context:
+            _ = ScriptArguments(dataset_name=None, dataset_mixture=None)
+        self.assertIn("Either `dataset_name` or `dataset_mixture` must be provided", str(context.exception))
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_data.py
+++ b/tests/utils/test_data.py
@@ -1,0 +1,113 @@
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+from dataclasses import asdict
+
+from datasets import DatasetDict, load_dataset
+
+from open_r1.configs import DatasetConfig, DatasetMixtureConfig, ScriptArguments
+from open_r1.utils.data import get_dataset
+
+
+class TestGetDataset(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.dataset_name = "trl-internal-testing/zen"
+        cls.dataset_config = "conversational_preference"
+        cls.ref_dataset = load_dataset(cls.dataset_name, cls.dataset_config)
+
+    def test_dataset_and_config_name(self):
+        args = ScriptArguments(dataset_name=self.dataset_name, dataset_config=self.dataset_config)
+        dataset = get_dataset(args)
+        self.assertIsInstance(dataset, DatasetDict)
+        self.assertIn("train", dataset)
+        self.assertEqual(len(dataset["train"]), len(self.ref_dataset["train"]))
+
+    def test_unweighted_mixture(self):
+        """Mix train and test splits of the same dataset."""
+        dataset_configs = [
+            DatasetConfig(id=self.dataset_name, config=self.dataset_config, split="train", columns=None, weight=None),
+            DatasetConfig(id=self.dataset_name, config=self.dataset_config, split="test", columns=None, weight=None),
+        ]
+        dataset_mixture = DatasetMixtureConfig(
+            datasets=dataset_configs,
+        )
+        args = ScriptArguments(dataset_mixture=asdict(dataset_mixture))
+        dataset = get_dataset(args)
+        self.assertIsInstance(dataset, DatasetDict)
+        self.assertIn("train", dataset)
+        self.assertEqual(len(dataset["train"]), len(self.ref_dataset["train"]) + len(self.ref_dataset["test"]))
+
+    def test_weighted_mixture(self):
+        """Test loading a dataset mixture with weights."""
+        dataset_configs = [
+            DatasetConfig(id=self.dataset_name, config=self.dataset_config, split="train", columns=None, weight=0.25),
+            DatasetConfig(id=self.dataset_name, config=self.dataset_config, split="test", columns=None, weight=0.5),
+        ]
+        dataset_mixture = DatasetMixtureConfig(
+            datasets=dataset_configs,
+        )
+        args = ScriptArguments(dataset_mixture=asdict(dataset_mixture))
+        dataset = get_dataset(args)
+        self.assertIsInstance(dataset, DatasetDict)
+        self.assertIn("train", dataset)
+        self.assertEqual(
+            len(dataset["train"]), len(self.ref_dataset["train"]) // 4 + len(self.ref_dataset["test"]) // 2
+        )
+
+    def test_mixture_and_test_split(self):
+        """Test loading a dataset mixture with test split."""
+        dataset_configs = [
+            DatasetConfig(
+                id=self.dataset_name, config=self.dataset_config, split="train[:10]", columns=None, weight=None
+            ),
+        ]
+        dataset_mixture = DatasetMixtureConfig(datasets=dataset_configs, test_split_size=0.2)
+        args = ScriptArguments(dataset_name=None, dataset_mixture=asdict(dataset_mixture))
+        dataset = get_dataset(args)
+        self.assertIsInstance(dataset, DatasetDict)
+        self.assertIn("train", dataset)
+        self.assertIn("test", dataset)
+        self.assertEqual(len(dataset["train"]), 8)
+        self.assertEqual(len(dataset["test"]), 2)
+
+    def test_mixture_column_selection(self):
+        """Test loading a dataset mixture with column selection."""
+        dataset_configs = [
+            DatasetConfig(
+                id=self.dataset_name,
+                config=self.dataset_config,
+                split="train",
+                columns=["prompt", "chosen"],
+                weight=None,
+            ),
+        ]
+        dataset_mixture = DatasetMixtureConfig(
+            datasets=dataset_configs,
+        )
+        args = ScriptArguments(dataset_mixture=asdict(dataset_mixture))
+        dataset = get_dataset(args)
+        self.assertIsInstance(dataset, DatasetDict)
+        self.assertIn("train", dataset)
+        self.assertIn("prompt", dataset["train"].column_names)
+        self.assertIn("chosen", dataset["train"].column_names)
+
+    def test_no_dataset_name_or_mixture(self):
+        with self.assertRaises(ValueError):
+            args = ScriptArguments(dataset_name=None, dataset_mixture=None)
+            get_dataset(args)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR implements an improved variant of the dataset mixer we had in the `alignment-handbook`, but with clearer intent and more fine-grained control to handle dataset configs.

Usage:

```py
# mix.py
from open_r1.configs import ScriptArguments
from trl import TrlParser
from open_r1.utils.data import get_dataset

import logging
logging.basicConfig(
    level=logging.INFO,
    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
    handlers=[logging.StreamHandler()]
)

parser = TrlParser(ScriptArguments)
args = parser.parse_args_and_config()[0]
print(args)

dataset = get_dataset(args)
print(dataset)
```

```yaml
# mix.yaml
dataset_mixture:
  datasets:
    - id: open-r1/OpenR1-Math-220k
      config: extended
      split: train[:100] # Select first 100 samples
      columns:
        - messages # Drop all other columns
      weight: 0.1 # Subsample from 100 -> 10
    - id: open-r1/codeforces-cots
      config: solutions_py
      split: train[:100]
      columns:
        - messages
      weight: 0.9 # Subsample from 100 -> 90
  seed: 0
  test_split_size: 0.25 # Create test split from concat of each config
```

```shell
python mix.py --config mix.yaml

DatasetDict({
    train: Dataset({
        features: ['messages'],
        num_rows: 75
    })
    test: Dataset({
        features: ['messages'],
        num_rows: 25
    })
})
```

## TODO

- [x] Add some docs
- [x] Integrate with SFT / GRPO scripts