### PR TITLE
Bump DeepSpeed to 0.16.8 to fix OOM on Qwen3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _deps = [
     "accelerate==1.4.0",
     "bitsandbytes>=0.43.0",
     "datasets>=3.2.0",
-    "deepspeed==0.16.7",
+    "deepspeed==0.16.8",
     "distilabel[vllm,ray,openai]>=1.5.2",
     "e2b-code-interpreter>=1.0.5",
     "einops>=0.8.0",


### PR DESCRIPTION
We need this version to avoid OOM with Qwen3-8B on 1 node of 8 x H100s: https://github.com/deepspeedai/DeepSpeed/pull/7258

SFT loss identical compared to v0.16.7:

![Screenshot 2025-05-21 at 22 22 16](https://github.com/user-attachments/assets/208807a7-8b7d-4374-a31b-98b5d12c11cc)
