### PR TITLE
Bump vLLM and TRL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ check_dirs := src tests
 # dev dependencies
 install:
 	uv venv openr1 --python 3.11 && . openr1/bin/activate && uv pip install --upgrade pip
-	uv pip install vllm==0.8.4
+	uv pip install vllm==0.8.5.post1
 	uv pip install setuptools
 	uv pip install flash-attn --no-build-isolation
 	GIT_LFS_SKIP_SMUDGE=1 uv pip install -e ".[dev]"

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,11 @@ check_dirs := src tests
 
 # dev dependencies
 install:
-	uv venv openr1 --python 3.11 && . openr1/bin/activate && uv pip install --upgrade pip
-	uv pip install vllm==0.8.5.post1
-	uv pip install setuptools
-	uv pip install flash-attn --no-build-isolation
+	uv venv openr1 --python 3.11
+	. openr1/bin/activate && uv pip install --upgrade pip && \
+	uv pip install vllm==0.8.5.post1 && \
+	uv pip install setuptools && \
+	uv pip install flash-attn --no-build-isolation && \
 	GIT_LFS_SKIP_SMUDGE=1 uv pip install -e ".[dev]"
 
 style:

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ _deps = [
     "sentencepiece>=0.1.99",
     "torch==2.6.0",
     "transformers==4.52.3",
-    "trl[vllm] @ git+https://github.com/huggingface/trl.git@9ac614fb081e17805f7f62ab3f5f7036bdefe7b0",  # Support for activation offload: https://github.com/huggingface/trl/pull/2954
+    "trl[vllm]==0.18.0",
     "wandb>=0.19.1",
     "async-lru>=2.0.5",
     "aiofiles>=24.1.0",


### PR DESCRIPTION
I've tested the SFT and GRPO sample scripts still run :)

AIME24 eval for Llama 8B also fine:

|       Task       |Version|        Metric        |Value |   |Stderr|
|------------------|------:|----------------------|-----:|---|-----:|
|all               |       |math_pass@1:1_samples |0.4000|±  |0.0910|
|                  |       |math_pass@1:4_samples |0.4667|±  |0.0696|
|                  |       |math_pass@1:8_samples |0.4667|±  |0.0656|
|                  |       |math_pass@1:16_samples|0.4604|±  |0.0639|
|                  |       |math_pass@1:32_samples|0.4594|±  |0.0634|
|                  |       |math_pass@1:64_samples|0.4510|±  |0.0640|
|lighteval:aime24:0|      2|math_pass@1:1_samples |0.4000|±  |0.0910|
|                  |       |math_pass@1:4_samples |0.4667|±  |0.0696|
|                  |       |math_pass@1:8_samples |0.4667|±  |0.0656|
|                  |       |math_pass@1:16_samples|0.4604|±  |0.0639|
|                  |       |math_pass@1:32_samples|0.4594|±  |0.0634|
|                  |       |math_pass@1:64_samples|0.4510|±  |0.0640|

Ran with

```
export VLLM_WORKER_MULTIPROC_METHOD=spawn
NUM_GPUS=8
MODEL=deepseek-ai/DeepSeek-R1-Distill-Llama-8B
MODEL_ARGS="model_name=$MODEL,dtype=bfloat16,data_parallel_size=$NUM_GPUS,max_model_length=32768,gpu_memory_utilization=0.8,generation_parameters={max_new_tokens:32768,temperature:0.6,top_p:0.95}"
TASK=aime24
OUTPUT_DIR=data/evals/$MODEL

lighteval vllm $MODEL_ARGS "lighteval|$TASK|0|0" \
    --use-chat-template \
    --output-dir $OUTPUT_DIR
```