### PR TITLE
Fix: update _run_script to use individual language per script execution.

### DIFF
--- a/src/open_r1/utils/code_providers.py
+++ b/src/open_r1/utils/code_providers.py
@@ -264,13 +264,13 @@ class MorphProvider(CodeExecutionProvider):
 
         semaphore = asyncio.Semaphore(num_parallel)
 
-        tasks = [self._run_script(script, languages, semaphore) for script in scripts]
+        tasks = [self._run_script(script, language, semaphore) for script, language in zip(scripts, languages)]
 
         results = await asyncio.gather(*tasks)
 
         return list(results)
 
-    async def _run_script(self, script: str, languages: List[str], semaphore: asyncio.Semaphore) -> float:
+    async def _run_script(self, script: str, language: str, semaphore: asyncio.Semaphore) -> float:
         """Execute a single script in a MorphCloud Sandbox.
 
         Args:
@@ -293,7 +293,7 @@ class MorphProvider(CodeExecutionProvider):
                     asyncio.to_thread(
                         sandbox.run_code,
                         script,
-                        languages=languages,
+                        language=language,
                         timeout=SANDBOX_TIMEOUT,
                     ),
                     timeout=ASYNCIO_TIMEOUT,


### PR DESCRIPTION
This PR fixes a bug in the `_run_script` method where script executions were always returning 0 reward due to incorrect language parameter handling.

**Changes:**
- Updated `_run_script` method signature to accept `language: str` instead of `languages: List[str]`
- Modified the task creation loop to zip scripts with their corresponding languages
- Updated the sandbox execution call to use the single language parameter

**Motivation:** The current implementation was incorrectly passing a list of languages to individual script executions, which caused all executions to return 0 reward instead of the expected evaluation scores.