### PR TITLE
feat(reward): add language consistency reward function

### DIFF
--- a/src/open_r1/configs.py
+++ b/src/open_r1/configs.py
@@ -229,6 +229,8 @@ class GRPOScriptArguments(ScriptArguments):
             Maximum number of tokens in completion.
         soft_punish_cache (`int`):
             Minimum number of tokens in completion.
+        txt_language (`str`):
+            Language for lang_consistency reward.
     """
 
     reward_funcs: list[str] = field(
@@ -328,4 +330,11 @@ class GRPOScriptArguments(ScriptArguments):
     soft_punish_cache: int = field(
         default=4096,
         metadata={"help": "Minimum number of characters in completion."},
+    )
+
+    txt_language: str = field(
+        default="en",
+        metadata={
+            "help": "Language for lang_consistency reward. Based on langdetect supported languages https://pypi.org/project/langdetect/"
+        },
     )


### PR DESCRIPTION
## Description

This pull request introduces a new reward function, `get_lang_consistency_reward`, to enhance the linguistic consistency of model outputs during reinforcement learning (e.g., GRPO).

### Motivation

In multilingual or even monolingual contexts, it's crucial for a model to adhere to the target language specified in a prompt or conversation. This reward function directly incentivizes this behavior by assigning a positive reward (1.0) only when the language of the generated completion matches the expected language. This helps prevent language drift and ensures more reliable and predictable model behavior.

Inspired by the "language consistency reward" concept from the DeepSeek-R1 paper, this function provides a valuable tool for fine-tuning models where strict language adherence is required.