### PR TITLE
Fix for Issue #684 : Locked flash-attn version to prevent ABI mismatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ install:
 	. openr1/bin/activate && uv pip install --upgrade pip && \
 	uv pip install vllm==0.8.5.post1 && \
 	uv pip install setuptools && \
-	uv pip install flash-attn --no-build-isolation && \
+	uv pip install flash-attn==2.7.4.post1 --no-build-isolation && \
 	GIT_LFS_SKIP_SMUDGE=1 uv pip install -e ".[dev]"
 
 style:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ uv venv openr1 --python 3.11 && source openr1/bin/activate && uv pip install --u
 > [!TIP]
 > For Hugging Face cluster users, add `export UV_LINK_MODE=copy` to your `.bashrc` to suppress cache warnings from `uv`
 
-Next, install vLLM and FlashAttention (use version 2.7.4.post1 to avoid ABI mismatches):
+Next, install vLLM and FlashAttention (use Flash Attention `v2.7.4.post1` to avoid ABI mismatches):
 
 ```shell
 uv pip install vllm==0.8.5.post1

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ uv venv openr1 --python 3.11 && source openr1/bin/activate && uv pip install --u
 > [!TIP]
 > For Hugging Face cluster users, add `export UV_LINK_MODE=copy` to your `.bashrc` to suppress cache warnings from `uv`
 
-Next, install vLLM and FlashAttention:
+Next, install vLLM and FlashAttention (use version 2.7.4.post1 to avoid ABI mismatches):
 
 ```shell
 uv pip install vllm==0.8.5.post1
-uv pip install setuptools && uv pip install flash-attn --no-build-isolation
+uv pip install setuptools && uv pip install flash-attn==2.7.4.post1 --no-build-isolation
 ```
 
 This will also install PyTorch `v2.6.0` and it is **very important** to use this version since the vLLM binaries are compiled for it. You can then install the remaining dependencies for your specific use case via `pip install -e .[LIST OF MODES]`. For most contributors, we recommend:


### PR DESCRIPTION
Previous code would automatically install latest flash-attn version, newer versions have a different ABI which is incompatible with torch 2.6.0, causing a MBI mismatch and binary issues. This fix proposes fixing flash-attn to a known working version to prevent future issues with dependency updates. Updates readme to explain to the user, as well as the makefile.

**I compiled and ran successfully on this version.**

Link to issue: https://github.com/huggingface/open-r1/issues/684