### PR TITLE
Add grounded information extraction rewards for GRPO

### DIFF
--- a/src/open_r1/configs.py
+++ b/src/open_r1/configs.py
@@ -234,7 +234,14 @@ class GRPOScriptArguments(ScriptArguments):
     reward_funcs: list[str] = field(
         default_factory=lambda: ["accuracy", "format", "tag_count"],
         metadata={
-            "help": "List of reward functions. Possible values: 'accuracy', 'format', 'reasoning_steps', 'cosine', 'repetition_penalty', 'length', tag_count', 'code', 'code_format'"
+            "help": (
+                "List of reward functions. "
+                "Math/code: 'accuracy', 'format', 'reasoning_steps', 'cosine', 'repetition_penalty', "
+                "'length', 'tag_count', 'code', 'binary_code', 'ioi_code', 'cf_code', 'code_format', "
+                "'soft_overlong_punishment'. "
+                "Grounded-R1 (information extraction): 'grounded_format', 'quote_grounding', "
+                "'answer_faithfulness', 'reasoning_quality'."
+            )
         },
     )
     cosine_min_value_wrong: float = field(

--- a/src/open_r1/grounded_rewards.py
+++ b/src/open_r1/grounded_rewards.py
@@ -1,0 +1,379 @@
+"""
+Reward functions for Grounded-R1: hallucination-free information extraction via GRPO.
+
+Signal stack (designed for additive composition in GRPOTrainer):
+  grounded_format_reward      — structural JSON compliance (max 1.0)
+  quote_grounding_reward      — exact substring matching against source context (max 1.0)
+  chunk_routing_reward        — v1: quote must come from the correct gold chunk (max 1.0)
+  answer_faithfulness_reward  — lexical faithfulness of final_answer to quotes (max 1.0)
+  reasoning_quality_reward    — non-trivial CoT encouragement (max 1.0)
+
+Every function matches the GRPOTrainer reward signature:
+  fn(completions: list[list[dict]], **kwargs) -> list[float | None]
+
+Dataset columns forwarded automatically by GRPOTrainer into kwargs:
+  context_raw      str  — concatenated passage text (all rewards)
+  context_chunks   str  — JSON {chunk_id: text}       (chunk_routing_reward only)
+  gold_chunk_ids   str  — JSON [chunk_id, ...]         (chunk_routing_reward only)
+"""
+
+import json
+import re
+from typing import Optional
+
+
+REQUIRED_KEYS = frozenset({"reasoning_path", "is_context_sufficient", "final_answer", "extracted_quotes"})
+REQUIRED_QUOTE_KEYS = frozenset({"chunk_id", "exact_quote"})
+
+_STOPWORDS = frozenset({
+    "the", "a", "an", "is", "are", "was", "were", "be", "been", "being",
+    "have", "has", "had", "do", "does", "did", "will", "would", "could",
+    "should", "may", "might", "shall", "can", "to", "of", "in", "for",
+    "on", "with", "at", "by", "from", "and", "or", "but", "not", "it",
+    "this", "that", "these", "those", "i", "you", "he", "she", "we", "they",
+})
+
+_INSUFFICIENT_PHRASES = frozenset({
+    "not contain", "insufficient", "cannot answer", "no information",
+    "not enough", "does not provide", "not mentioned", "not found",
+    "unable to answer", "no relevant", "context does not",
+    "does not contain", "no sufficient",
+})
+
+_SUFFICIENCY_VOCAB = frozenset({
+    "sufficient", "insufficient", "enough", "context", "contains",
+    "mentions", "found", "relevant", "available", "provided", "answer",
+    "information", "passage", "supports",
+})
+
+
+def _parse_grounded_response(content: str) -> Optional[dict]:
+    """Extract and parse the JSON payload from a model completion.
+
+    Tries (in order): ```json block, bare JSON object anywhere in content.
+    Returns None if no valid JSON is found.
+    """
+    m = re.search(r"```json\s*(.*?)\s*```", content, re.DOTALL)
+    if m:
+        try:
+            return json.loads(m.group(1))
+        except json.JSONDecodeError:
+            pass
+
+    m = re.search(r"\{.*\}", content, re.DOTALL)
+    if m:
+        try:
+            return json.loads(m.group(0))
+        except json.JSONDecodeError:
+            pass
+
+    return None
+
+
+def _is_grounded(quote: str, context: str) -> bool:
+    """Check if quote is an exact (or whitespace-normalised) substring of context."""
+    if not quote:
+        return False
+    if quote in context:
+        return True
+    # Normalise consecutive whitespace — handles tokeniser artefacts
+    normalised_quote = " ".join(quote.split())
+    normalised_ctx = " ".join(context.split())
+    return normalised_quote in normalised_ctx
+
+
+# ---------------------------------------------------------------------------
+# Reward 1 — Structural compliance
+# ---------------------------------------------------------------------------
+
+def grounded_format_reward(completions, **kwargs) -> list[float]:
+    """
+    Verifies the JSON schema of the grounded response.
+
+    Additive scoring (max 1.0):
+      +0.25  response is valid JSON
+      +0.25  all four required top-level keys are present
+      +0.25  correct field types (bool, list, str)
+      +0.25  every item in extracted_quotes has non-empty chunk_id + exact_quote strings
+    """
+    rewards = []
+    for completion in completions:
+        content = completion[0]["content"]
+
+        parsed = _parse_grounded_response(content)
+        if parsed is None:
+            rewards.append(0.0)
+            continue
+        score = 0.25
+
+        if not REQUIRED_KEYS.issubset(parsed.keys()):
+            rewards.append(score)
+            continue
+        score += 0.25
+
+        type_ok = (
+            isinstance(parsed["reasoning_path"], str)
+            and isinstance(parsed["is_context_sufficient"], bool)
+            and isinstance(parsed["final_answer"], str)
+            and isinstance(parsed["extracted_quotes"], list)
+        )
+        if not type_ok:
+            rewards.append(score)
+            continue
+        score += 0.25
+
+        quotes = parsed["extracted_quotes"]
+        quotes_ok = not quotes or all(
+            isinstance(q, dict)
+            and REQUIRED_QUOTE_KEYS.issubset(q.keys())
+            and isinstance(q["chunk_id"], str)
+            and isinstance(q["exact_quote"], str)
+            and len(q["exact_quote"].strip()) > 0
+            for q in quotes
+        )
+        if quotes_ok:
+            score += 0.25
+
+        rewards.append(score)
+    return rewards
+
+
+# ---------------------------------------------------------------------------
+# Reward 2 — Quote grounding (core anti-hallucination signal)
+# ---------------------------------------------------------------------------
+
+def quote_grounding_reward(completions, context_raw: list[str], **kwargs) -> list[float]:
+    """
+    Verifies that every extracted_quote is a verbatim substring of the source context.
+
+    This is the primary reward signal for eradicating factual hallucinations.
+
+    Scoring logic:
+      is_context_sufficient=True,  quotes non-empty  →  mean(exact_match per quote)  [0, 1]
+      is_context_sufficient=True,  quotes empty      →  0.0   (claimed sufficient, cited nothing)
+      is_context_sufficient=False, quotes empty      →  1.0   (correctly abstained)
+      is_context_sufficient=False, quotes non-empty  →  scored normally (partial credit)
+    """
+    rewards = []
+    for completion, ctx in zip(completions, context_raw):
+        content = completion[0]["content"]
+        parsed = _parse_grounded_response(content)
+
+        if parsed is None or not REQUIRED_KEYS.issubset(parsed.keys()):
+            rewards.append(0.0)
+            continue
+
+        quotes = parsed["extracted_quotes"]
+        is_sufficient = parsed["is_context_sufficient"]
+
+        if not is_sufficient and not quotes:
+            rewards.append(1.0)
+            continue
+
+        if is_sufficient and not quotes:
+            rewards.append(0.0)
+            continue
+
+        valid_quotes = [
+            q for q in quotes
+            if isinstance(q, dict) and q.get("exact_quote", "").strip()
+        ]
+        if not valid_quotes:
+            rewards.append(0.0)
+            continue
+
+        grounded_count = sum(1 for q in valid_quotes if _is_grounded(q["exact_quote"], ctx))
+        rewards.append(grounded_count / len(valid_quotes))
+
+    return rewards
+
+
+# ---------------------------------------------------------------------------
+# Reward 3 — Answer faithfulness
+# ---------------------------------------------------------------------------
+
+def answer_faithfulness_reward(completions, **kwargs) -> list[float]:
+    """
+    Checks that the final_answer is lexically supported by the extracted_quotes,
+    preventing the model from using grounded quotes as a cover while hallucinating
+    the synthesised answer.
+
+    Score = |content_tokens(answer) ∩ content_tokens(all_quotes)| / |content_tokens(answer)|
+
+    For is_context_sufficient=False: checks that the answer contains an abstention phrase.
+    """
+    rewards = []
+    for completion in completions:
+        content = completion[0]["content"]
+        parsed = _parse_grounded_response(content)
+
+        if parsed is None or not REQUIRED_KEYS.issubset(parsed.keys()):
+            rewards.append(0.0)
+            continue
+
+        final_answer = parsed["final_answer"]
+        quotes = parsed["extracted_quotes"]
+        is_sufficient = parsed["is_context_sufficient"]
+
+        if not is_sufficient:
+            answer_lower = final_answer.lower()
+            reward = 1.0 if any(p in answer_lower for p in _INSUFFICIENT_PHRASES) else 0.2
+            rewards.append(reward)
+            continue
+
+        if not quotes or not final_answer.strip():
+            rewards.append(0.0)
+            continue
+
+        quote_text = " ".join(
+            q.get("exact_quote", "") for q in quotes if isinstance(q, dict)
+        )
+        quote_tokens = {
+            t.lower()
+            for t in re.findall(r"\b\w+\b", quote_text)
+            if t.lower() not in _STOPWORDS
+        }
+        answer_tokens = {
+            t.lower()
+            for t in re.findall(r"\b\w+\b", final_answer)
+            if t.lower() not in _STOPWORDS
+        }
+
+        if not answer_tokens:
+            rewards.append(0.0)
+            continue
+
+        overlap = len(answer_tokens & quote_tokens) / len(answer_tokens)
+        rewards.append(float(overlap))
+
+    return rewards
+
+
+# ---------------------------------------------------------------------------
+# Reward 4 — Reasoning quality (soft, encourages CoT)
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Reward 3b — Chunk routing (v1, multi-chunk contexts)
+# ---------------------------------------------------------------------------
+
+def chunk_routing_reward(
+    completions,
+    context_chunks: list[str],
+    gold_chunk_ids: list[str],
+    **kwargs,
+) -> list[float]:
+    """
+    Verifies that each extracted_quote comes from a gold (supporting) chunk,
+    not from a distractor chunk.
+
+    This is the key v1 reward for multi-passage contexts (e.g. HotpotQA).
+    It sits on top of quote_grounding_reward: a quote must both exist verbatim
+    in the source AND originate from the correct passage.
+
+    Args:
+        context_chunks:  list of JSON strings, each encoding {chunk_id: text}.
+        gold_chunk_ids:  list of JSON strings, each encoding [chunk_id, ...].
+                         Empty list means the question is unanswerable.
+
+    Scoring:
+      is_context_sufficient=True, gold non-empty, quotes present:
+          mean(1.0 if chunk_id ∈ gold_ids AND exact_quote ∈ chunk_text else 0.0)
+      is_context_sufficient=False, gold empty (truly unanswerable):
+          1.0 — correct abstention
+      is_context_sufficient=True,  gold empty:
+          0.0 — claimed sufficient when nothing is answerable
+      is_context_sufficient=False, gold non-empty:
+          0.0 — wrongly abstained when context is sufficient
+      No quotes when sufficient:
+          0.0
+    """
+    rewards = []
+    for completion, chunks_json, gold_json in zip(completions, context_chunks, gold_chunk_ids):
+        content = completion[0]["content"]
+        parsed = _parse_grounded_response(content)
+
+        if parsed is None or not REQUIRED_KEYS.issubset(parsed.keys()):
+            rewards.append(0.0)
+            continue
+
+        try:
+            chunk_dict: dict[str, str] = json.loads(chunks_json)
+            gold_ids: list[str] = json.loads(gold_json)
+        except (json.JSONDecodeError, TypeError):
+            rewards.append(0.0)
+            continue
+
+        is_sufficient = parsed["is_context_sufficient"]
+        quotes = parsed["extracted_quotes"]
+        is_truly_unanswerable = len(gold_ids) == 0
+
+        # Correct abstention
+        if is_truly_unanswerable and not is_sufficient and not quotes:
+            rewards.append(1.0)
+            continue
+
+        # Wrong claim of sufficiency for unanswerable
+        if is_truly_unanswerable and is_sufficient:
+            rewards.append(0.0)
+            continue
+
+        # Wrong abstention for answerable
+        if not is_truly_unanswerable and not is_sufficient:
+            rewards.append(0.0)
+            continue
+
+        # No quotes when claimed sufficient
+        valid_quotes = [q for q in quotes if isinstance(q, dict) and q.get("exact_quote", "").strip()]
+        if not valid_quotes:
+            rewards.append(0.0)
+            continue
+
+        # Score each quote: gold chunk + grounded in that chunk
+        scores = []
+        for q in valid_quotes:
+            cid = q.get("chunk_id", "")
+            eq = q.get("exact_quote", "")
+            chunk_text = chunk_dict.get(cid, "")
+            routed_correctly = cid in gold_ids
+            grounded_in_chunk = _is_grounded(eq, chunk_text)
+            scores.append(1.0 if (routed_correctly and grounded_in_chunk) else 0.0)
+
+        rewards.append(sum(scores) / len(scores))
+
+    return rewards
+
+
+# ---------------------------------------------------------------------------
+# Reward 4 — Reasoning quality (soft, encourages CoT)
+# ---------------------------------------------------------------------------
+
+def reasoning_quality_reward(completions, **kwargs) -> list[float]:
+    """
+    Soft reward encouraging a substantive chain-of-thought in reasoning_path.
+
+    +0.5   reasoning_path is non-empty
+    +0.3   mentions sufficiency-assessment vocabulary
+    +0.2   at least 20 words (penalises trivial one-liners)
+    """
+    rewards = []
+    for completion in completions:
+        content = completion[0]["content"]
+        parsed = _parse_grounded_response(content)
+
+        if parsed is None or "reasoning_path" not in parsed:
+            rewards.append(0.0)
+            continue
+
+        reasoning = parsed["reasoning_path"]
+        score = 0.0
+
+        if reasoning.strip():
+            score += 0.5
+            if any(kw in reasoning.lower() for kw in _SUFFICIENCY_VOCAB):
+                score += 0.3
+            if len(reasoning.split()) >= 20:
+                score += 0.2
+
+        rewards.append(score)
+    return rewards

--- a/src/open_r1/rewards.py
+++ b/src/open_r1/rewards.py
@@ -25,6 +25,13 @@ from typing import Callable, Dict, Literal, Optional
 from latex2sympy2_extended import NormalizationConfig
 from math_verify import LatexExtractionConfig, parse, verify
 
+from .grounded_rewards import (
+    answer_faithfulness_reward,
+    chunk_routing_reward,
+    grounded_format_reward,
+    quote_grounding_reward,
+    reasoning_quality_reward,
+)
 from .utils.code_providers import get_provider
 from .utils.competitive_programming import (
     SubtaskResult,
@@ -700,6 +707,13 @@ def get_reward_funcs(script_args) -> list[Callable]:
             max_completion_len=script_args.max_completion_len,
             soft_punish_cache=script_args.soft_punish_cache,
         ),
+        # --- Grounded-R1 rewards (v0) ---
+        "grounded_format": grounded_format_reward,
+        "quote_grounding": quote_grounding_reward,
+        "answer_faithfulness": answer_faithfulness_reward,
+        "reasoning_quality": reasoning_quality_reward,
+        # --- Grounded-R1 rewards (v1 multi-chunk) ---
+        "chunk_routing": chunk_routing_reward,
     }
     reward_funcs = [REWARD_FUNCS_REGISTRY[func] for func in script_args.reward_funcs]
 

--- a/tests/test_grounded_rewards.py
+++ b/tests/test_grounded_rewards.py
@@ -1,0 +1,407 @@
+"""Unit tests for Grounded-R1 reward functions."""
+
+import json
+
+from open_r1.grounded_rewards import (
+    _is_grounded,
+    _parse_grounded_response,
+    answer_faithfulness_reward,
+    chunk_routing_reward,
+    grounded_format_reward,
+    quote_grounding_reward,
+    reasoning_quality_reward,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_completion(content: str) -> list[list[dict]]:
+    """Wrap raw content into the GRPOTrainer completion format."""
+    return [[{"role": "assistant", "content": content}]]
+
+
+def _json_completion(payload: dict) -> list[list[dict]]:
+    return _make_completion(json.dumps(payload))
+
+
+GOOD_RESPONSE = {
+    "reasoning_path": (
+        "I will check whether the context contains information about the capital of France. "
+        "The context states 'Paris is the capital of France', which is sufficient to answer the question. "
+        "I will extract the relevant quote directly from the provided passage."
+    ),
+    "is_context_sufficient": True,
+    "final_answer": "Paris is the capital of France.",
+    "extracted_quotes": [
+        {"chunk_id": "doc_0", "exact_quote": "Paris is the capital of France"}
+    ],
+}
+
+CONTEXT = "Paris is the capital of France and a major European city."
+
+
+# ---------------------------------------------------------------------------
+# _parse_grounded_response
+# ---------------------------------------------------------------------------
+
+class TestParseGroundedResponse:
+    def test_json_block(self):
+        content = f"```json\n{json.dumps(GOOD_RESPONSE)}\n```"
+        assert _parse_grounded_response(content) == GOOD_RESPONSE
+
+    def test_bare_json(self):
+        assert _parse_grounded_response(json.dumps(GOOD_RESPONSE)) == GOOD_RESPONSE
+
+    def test_embedded_in_text(self):
+        content = f"Here is my answer: {json.dumps(GOOD_RESPONSE)} Done."
+        result = _parse_grounded_response(content)
+        assert result == GOOD_RESPONSE
+
+    def test_invalid_returns_none(self):
+        assert _parse_grounded_response("not json at all") is None
+        assert _parse_grounded_response("") is None
+
+
+# ---------------------------------------------------------------------------
+# _is_grounded
+# ---------------------------------------------------------------------------
+
+class TestIsGrounded:
+    def test_exact_match(self):
+        assert _is_grounded("Paris is the capital", "Paris is the capital of France")
+
+    def test_no_match(self):
+        assert not _is_grounded("London is the capital", "Paris is the capital of France")
+
+    def test_whitespace_normalisation(self):
+        assert _is_grounded("Paris  is  the  capital", "Paris is the capital of France")
+
+    def test_empty_quote_is_false(self):
+        assert not _is_grounded("", "Paris is the capital of France")
+
+
+# ---------------------------------------------------------------------------
+# grounded_format_reward
+# ---------------------------------------------------------------------------
+
+class TestGroundedFormatReward:
+    def test_perfect_response_scores_1(self):
+        rewards = grounded_format_reward(_json_completion(GOOD_RESPONSE))
+        assert rewards == [1.0]
+
+    def test_invalid_json_scores_0(self):
+        rewards = grounded_format_reward(_make_completion("this is not json"))
+        assert rewards == [0.0]
+
+    def test_missing_key_partial_score(self):
+        incomplete = {k: v for k, v in GOOD_RESPONSE.items() if k != "extracted_quotes"}
+        rewards = grounded_format_reward(_json_completion(incomplete))
+        assert rewards == [0.25]  # JSON parseable (+0.25), but missing key → stops there
+
+    def test_wrong_type_for_is_context_sufficient(self):
+        bad = dict(GOOD_RESPONSE, is_context_sufficient="yes")
+        rewards = grounded_format_reward(_json_completion(bad))
+        assert rewards == [0.5]  # 0.25 JSON + 0.25 keys, type check fails
+
+    def test_empty_quotes_list_is_valid(self):
+        """Empty extracted_quotes is structurally fine (unanswerable case)."""
+        payload = dict(GOOD_RESPONSE, is_context_sufficient=False, extracted_quotes=[])
+        rewards = grounded_format_reward(_json_completion(payload))
+        assert rewards == [1.0]
+
+    def test_batch_processing(self):
+        completions = _json_completion(GOOD_RESPONSE) + _make_completion("garbage")
+        rewards = grounded_format_reward(completions)
+        assert rewards[0] == 1.0
+        assert rewards[1] == 0.0
+
+    def test_empty_exact_quote_string_penalised(self):
+        bad_quotes = dict(GOOD_RESPONSE, extracted_quotes=[{"chunk_id": "a", "exact_quote": ""}])
+        rewards = grounded_format_reward(_json_completion(bad_quotes))
+        assert rewards == [0.75]  # fails last +0.25
+
+
+# ---------------------------------------------------------------------------
+# quote_grounding_reward
+# ---------------------------------------------------------------------------
+
+class TestQuoteGroundingReward:
+    def test_exact_grounded_quote_scores_1(self):
+        rewards = quote_grounding_reward(_json_completion(GOOD_RESPONSE), context_raw=[CONTEXT])
+        assert rewards == [1.0]
+
+    def test_hallucinated_quote_scores_0(self):
+        hallucinated = dict(
+            GOOD_RESPONSE,
+            extracted_quotes=[{"chunk_id": "doc_0", "exact_quote": "London is the capital of England"}],
+        )
+        rewards = quote_grounding_reward(_json_completion(hallucinated), context_raw=[CONTEXT])
+        assert rewards == [0.0]
+
+    def test_partial_grounding(self):
+        mixed = dict(
+            GOOD_RESPONSE,
+            extracted_quotes=[
+                {"chunk_id": "doc_0", "exact_quote": "Paris is the capital of France"},
+                {"chunk_id": "doc_0", "exact_quote": "This sentence does not exist anywhere"},
+            ],
+        )
+        rewards = quote_grounding_reward(_json_completion(mixed), context_raw=[CONTEXT])
+        assert rewards == [0.5]
+
+    def test_correct_abstention_scores_1(self):
+        abstain = dict(
+            GOOD_RESPONSE,
+            is_context_sufficient=False,
+            extracted_quotes=[],
+            final_answer="The provided context does not contain sufficient information.",
+        )
+        rewards = quote_grounding_reward(_json_completion(abstain), context_raw=[CONTEXT])
+        assert rewards == [1.0]
+
+    def test_false_sufficiency_with_no_quotes_scores_0(self):
+        bad = dict(GOOD_RESPONSE, is_context_sufficient=True, extracted_quotes=[])
+        rewards = quote_grounding_reward(_json_completion(bad), context_raw=[CONTEXT])
+        assert rewards == [0.0]
+
+    def test_invalid_completion_scores_0(self):
+        rewards = quote_grounding_reward(_make_completion("not json"), context_raw=[CONTEXT])
+        assert rewards == [0.0]
+
+
+# ---------------------------------------------------------------------------
+# answer_faithfulness_reward
+# ---------------------------------------------------------------------------
+
+class TestAnswerFaithfulnessReward:
+    def test_faithful_answer_scores_high(self):
+        rewards = answer_faithfulness_reward(_json_completion(GOOD_RESPONSE))
+        assert rewards[0] > 0.5
+
+    def test_abstention_answer_for_insufficient_context(self):
+        abstain = dict(
+            GOOD_RESPONSE,
+            is_context_sufficient=False,
+            extracted_quotes=[],
+            final_answer="The provided context does not contain sufficient information to answer this question.",
+        )
+        rewards = answer_faithfulness_reward(_json_completion(abstain))
+        assert rewards == [1.0]
+
+    def test_hallucinated_answer_with_good_quotes_penalised(self):
+        hallucinated_answer = dict(
+            GOOD_RESPONSE,
+            final_answer="Jupiter is the largest planet in the solar system.",
+        )
+        rewards = answer_faithfulness_reward(_json_completion(hallucinated_answer))
+        assert rewards[0] < 0.2
+
+    def test_invalid_completion_scores_0(self):
+        rewards = answer_faithfulness_reward(_make_completion("garbage"))
+        assert rewards == [0.0]
+
+
+# ---------------------------------------------------------------------------
+# reasoning_quality_reward
+# ---------------------------------------------------------------------------
+
+class TestReasoningQualityReward:
+    def test_good_reasoning_scores_1(self):
+        rewards = reasoning_quality_reward(_json_completion(GOOD_RESPONSE))
+        assert rewards == [1.0]
+
+    def test_empty_reasoning_scores_0(self):
+        empty_reasoning = dict(GOOD_RESPONSE, reasoning_path="")
+        rewards = reasoning_quality_reward(_json_completion(empty_reasoning))
+        assert rewards == [0.0]
+
+    def test_short_reasoning_without_vocab_scores_half(self):
+        # No sufficiency vocab words, under 20 words → only +0.5 for non-empty
+        short = dict(GOOD_RESPONSE, reasoning_path="Checking the text now.")
+        rewards = reasoning_quality_reward(_json_completion(short))
+        assert rewards == [0.5]
+
+    def test_invalid_completion_scores_0(self):
+        rewards = reasoning_quality_reward(_make_completion("not json"))
+        assert rewards == [0.0]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: reward interaction
+# ---------------------------------------------------------------------------
+
+class TestEndToEnd:
+    def test_perfect_response_all_rewards_max(self):
+        completions = _json_completion(GOOD_RESPONSE)
+        ctx = [CONTEXT]
+        fmt = grounded_format_reward(completions)
+        grnd = quote_grounding_reward(completions, context_raw=ctx)
+        faith = answer_faithfulness_reward(completions)
+        rsn = reasoning_quality_reward(completions)
+        assert fmt == [1.0]
+        assert grnd == [1.0]
+        assert faith[0] > 0.5
+        assert rsn == [1.0]
+
+    def test_hallucinated_response_penalised_across_signals(self):
+        hallucinated = {
+            "reasoning_path": "The context mentions that London is the capital.",
+            "is_context_sufficient": True,
+            "final_answer": "London is the capital of the UK.",
+            "extracted_quotes": [
+                {"chunk_id": "doc_0", "exact_quote": "London is the capital of the United Kingdom"}
+            ],
+        }
+        completions = _json_completion(hallucinated)
+        ctx = [CONTEXT]
+        grnd = quote_grounding_reward(completions, context_raw=ctx)
+        faith = answer_faithfulness_reward(completions)
+        assert grnd == [0.0]   # quote not in context → grounding = 0
+        assert faith[0] > 0.5  # answer IS consistent with the (hallucinated) quote — faithfulness is internal
+
+
+# ---------------------------------------------------------------------------
+# chunk_routing_reward (v1 — multi-chunk contexts)
+# ---------------------------------------------------------------------------
+
+# Multi-chunk test fixtures
+CHUNK_A = "Paris is the capital of France and a major European city."
+CHUNK_B = "Berlin is the capital of Germany, located in central Europe."
+CHUNK_C = "London is the capital of the United Kingdom and a financial hub."
+
+MULTI_CHUNKS = json.dumps({
+    "France_0": CHUNK_A,
+    "Germany_0": CHUNK_B,
+    "UK_0": CHUNK_C,
+})
+GOLD_IDS = json.dumps(["France_0"])  # only France chunk is relevant
+
+
+def _routing_completion(is_sufficient: bool, answer: str, quotes: list[dict],
+                        reasoning: str = "Checked all chunks for relevant information about France.") -> list:
+    payload = {
+        "reasoning_path": reasoning,
+        "is_context_sufficient": is_sufficient,
+        "final_answer": answer,
+        "extracted_quotes": quotes,
+    }
+    return _json_completion(payload)
+
+
+class TestChunkRoutingReward:
+    def test_perfect_routing_scores_1(self):
+        """Quote from gold chunk, verbatim substring → 1.0."""
+        completions = _routing_completion(
+            True, "Paris",
+            [{"chunk_id": "France_0", "exact_quote": "Paris is the capital of France"}],
+        )
+        rewards = chunk_routing_reward(completions, context_chunks=[MULTI_CHUNKS], gold_chunk_ids=[GOLD_IDS])
+        assert rewards == [1.0]
+
+    def test_distractor_chunk_scores_0(self):
+        """Quote from a distractor chunk, even if verbatim → 0.0."""
+        completions = _routing_completion(
+            True, "Berlin",
+            [{"chunk_id": "Germany_0", "exact_quote": "Berlin is the capital of Germany"}],
+        )
+        rewards = chunk_routing_reward(completions, context_chunks=[MULTI_CHUNKS], gold_chunk_ids=[GOLD_IDS])
+        assert rewards == [0.0]
+
+    def test_gold_chunk_but_hallucinated_quote_scores_0(self):
+        """Correct chunk id, but exact_quote not in that chunk → 0.0."""
+        completions = _routing_completion(
+            True, "Paris",
+            [{"chunk_id": "France_0", "exact_quote": "Paris has always been the greatest city"}],
+        )
+        rewards = chunk_routing_reward(completions, context_chunks=[MULTI_CHUNKS], gold_chunk_ids=[GOLD_IDS])
+        assert rewards == [0.0]
+
+    def test_partial_routing_half_score(self):
+        """One routed correctly, one from distractor → 0.5."""
+        completions = _routing_completion(
+            True, "Paris and Berlin",
+            [
+                {"chunk_id": "France_0", "exact_quote": "Paris is the capital of France"},
+                {"chunk_id": "Germany_0", "exact_quote": "Berlin is the capital of Germany"},
+            ],
+        )
+        rewards = chunk_routing_reward(completions, context_chunks=[MULTI_CHUNKS], gold_chunk_ids=[GOLD_IDS])
+        assert rewards == [0.5]
+
+    def test_correct_abstention_unanswerable(self):
+        """gold_chunk_ids=[], is_context_sufficient=False, no quotes → 1.0."""
+        completions = _routing_completion(
+            False,
+            "The provided context does not contain sufficient information.",
+            [],
+            reasoning="None of the provided chunks mention the capital of Mars, context is insufficient.",
+        )
+        empty_gold = json.dumps([])
+        rewards = chunk_routing_reward(completions, context_chunks=[MULTI_CHUNKS], gold_chunk_ids=[empty_gold])
+        assert rewards == [1.0]
+
+    def test_wrong_sufficiency_claim_for_unanswerable(self):
+        """gold_chunk_ids=[], is_context_sufficient=True → 0.0 (should have abstained)."""
+        completions = _routing_completion(
+            True, "Paris",
+            [{"chunk_id": "France_0", "exact_quote": "Paris is the capital of France"}],
+        )
+        empty_gold = json.dumps([])
+        rewards = chunk_routing_reward(completions, context_chunks=[MULTI_CHUNKS], gold_chunk_ids=[empty_gold])
+        assert rewards == [0.0]
+
+    def test_wrong_abstention_for_answerable(self):
+        """gold_chunk_ids non-empty, is_context_sufficient=False → 0.0 (missed the answer)."""
+        completions = _routing_completion(
+            False,
+            "The provided context does not contain sufficient information.",
+            [],
+        )
+        rewards = chunk_routing_reward(completions, context_chunks=[MULTI_CHUNKS], gold_chunk_ids=[GOLD_IDS])
+        assert rewards == [0.0]
+
+    def test_invalid_json_scores_0(self):
+        rewards = chunk_routing_reward(
+            _make_completion("not json"),
+            context_chunks=[MULTI_CHUNKS],
+            gold_chunk_ids=[GOLD_IDS],
+        )
+        assert rewards == [0.0]
+
+    def test_no_quotes_when_sufficient_scores_0(self):
+        completions = _routing_completion(True, "Paris", [])
+        rewards = chunk_routing_reward(completions, context_chunks=[MULTI_CHUNKS], gold_chunk_ids=[GOLD_IDS])
+        assert rewards == [0.0]
+
+    def test_multi_gold_chunks_hotpotqa_style(self):
+        """Two gold chunks (HotpotQA bridge questions), both cited correctly → 1.0."""
+        two_gold = json.dumps(["France_0", "Germany_0"])
+        completions = _routing_completion(
+            True, "Both Paris and Berlin are capitals in Europe.",
+            [
+                {"chunk_id": "France_0", "exact_quote": "Paris is the capital of France"},
+                {"chunk_id": "Germany_0", "exact_quote": "Berlin is the capital of Germany"},
+            ],
+        )
+        rewards = chunk_routing_reward(completions, context_chunks=[MULTI_CHUNKS], gold_chunk_ids=[two_gold])
+        assert rewards == [1.0]
+
+    def test_batch_processing(self):
+        """Two examples processed in one call."""
+        comp_good = _routing_completion(
+            True, "Paris",
+            [{"chunk_id": "France_0", "exact_quote": "Paris is the capital of France"}],
+        )
+        comp_bad = _routing_completion(
+            True, "Berlin",
+            [{"chunk_id": "Germany_0", "exact_quote": "Berlin is the capital of Germany"}],
+        )
+        completions = comp_good + comp_bad
+        rewards = chunk_routing_reward(
+            completions,
+            context_chunks=[MULTI_CHUNKS, MULTI_CHUNKS],
+            gold_chunk_ids=[GOLD_IDS, GOLD_IDS],
+        )
+        assert rewards == [1.0, 0.0]


### PR DESCRIPTION
## Motivation

  GRPO's reward machinery is domain-agnostic — there's no reason to limit it to math. This
  PR adds 5 composable reward functions for hallucination-free information extraction via
  GRPO.

  **Core idea**: instead of rewarding correct math answers, reward the model for verbatim
  citations. Every `extracted_quote` must be an exact substring of the source context. This
  eradicates factual hallucinations at training time.

  ## Output format

  ```json
  {
    "reasoning_path": "<chain-of-thought>",
    "is_context_sufficient": true,
    "final_answer": "<answer>",
    "extracted_quotes": [
      {"chunk_id": "doc_0", "exact_quote": "<verbatim substring from context>"}
    ]
  }

  New reward functions

  Reward: grounded_format
  Signal: Additive JSON schema check — valid JSON → keys → types → quote structure
  ────────────────────────────────────────
  Reward: quote_grounding
  Signal: exact_quote ∈ context_raw — core anti-hallucination signal
  ────────────────────────────────────────
  Reward: chunk_routing
  Signal: Quote must come from the correct gold chunk, not a distractor
  ────────────────────────────────────────
  Reward: answer_faithfulness
  Signal: Token overlap between final_answer and extracted quotes
  ────────────────────────────────────────
  Reward: reasoning_quality
  Signal: Encourages substantive CoT

  All functions register in REWARD_FUNCS_REGISTRY. Activate via reward_funcs: 
  [grounded_format, quote_grounding, ...] in any GRPO recipe YAML — zero changes to the
  training loop.

  Tests

  42 tests, all passing. Covers hallucination detection, correct abstention, partial
  grounding, batch processing, multi-chunk routing.